### PR TITLE
Bug/webexperiment batterystatus

### DIFF
--- a/ExperimentRunner/Batterystats.py
+++ b/ExperimentRunner/Batterystats.py
@@ -80,9 +80,11 @@ class Batterystats(Profiler):
         batterystats_results = Parser.parse_batterystats(app, batterystats_file, self.powerprofile)
 
         # Estimate total consumption
+        # charge is given in mAh
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
-        energy_consumed = (float(charge) / 1000) * (float(volt) / 1000.0) * 3600.0
+        energy_consumed_Wh = float(charge) * float(volt) / 1000.0
+        energy_consumed_J = energy_consumed_Wh * 3600.0
 
         # Wait for Systrace file finalisation before parsing
         sysproc.wait()
@@ -94,8 +96,10 @@ class Batterystats(Profiler):
             writer.writerow(['Start Time (Seconds),End Time (Seconds),Duration (Seconds),Component,Energy Consumption (Joule)'])
             writer.writerow(batterystats_results)
             writer.writerow(systrace_results)
-            writer.writerow([''])
-            writer.writerow(['Android Internal Estimation:,{}'.format(energy_consumed)])
+
+        with open(op.join(paths.OUTPUT_DIR, 'android',
+                          'energy_consumed_Joule.txt')) as out:
+            out.write('{}\n'.format(energy_consumed_J))
 
         # Remove log files
         if self.cleanup is True:

--- a/ExperimentRunner/Batterystats.py
+++ b/ExperimentRunner/Batterystats.py
@@ -28,9 +28,7 @@ class Batterystats(Profiler):
     def start_profiling(self, device, **kwargs):
         # Reset logs on the device
         device.shell('dumpsys batterystats --reset')
-        device.shell('logcat -c')
         print('Batterystats cleared')
-        print('Logcat cleared')
 
         # Create output directories
         global app

--- a/ExperimentRunner/Experiment.py
+++ b/ExperimentRunner/Experiment.py
@@ -79,6 +79,8 @@ class Experiment(object):
     def before_run(self, device, path, run, *args, **kwargs):
         """Hook executed before a run"""
         self.logger.info('Run %s of %s' % (run + 1, self.replications))
+        device.shell('logcat -c')
+        self.logger.info('Logcat cleared')
         self.scripts.run('before_run', device, *args, **kwargs)
 
     def after_launch(self, device, path, run, *args, **kwargs):

--- a/ExperimentRunner/Parser.py
+++ b/ExperimentRunner/Parser.py
@@ -88,7 +88,10 @@ def parse_batterystats(app, batterystats_file, power_profile):
 
         bs_file.seek(0)
         for line in bs_file:
-            current_time = convert_to_s(time_pattern.search(line).group(1))
+            time_pattern_match = time_pattern.search(line)
+            if not time_pattern_match:
+                continue
+            current_time = convert_to_s(time_pattern_match.group(1))
 
             if voltage_pattern.search(line):
                 voltage = get_voltage(line)

--- a/ExperimentRunner/WebExperiment.py
+++ b/ExperimentRunner/WebExperiment.py
@@ -36,8 +36,6 @@ class WebExperiment(Experiment):
 
     def before_run(self, device, path, run, *args, **kwargs):
         super(WebExperiment, self).before_run(device, path, run)
-        device.shell('logcat -c')
-        print('Logcat cleared')
         browser = args[0]
         browser.start(device)
         time.sleep(5)

--- a/ExperimentRunner/WebExperiment.py
+++ b/ExperimentRunner/WebExperiment.py
@@ -36,6 +36,8 @@ class WebExperiment(Experiment):
 
     def before_run(self, device, path, run, *args, **kwargs):
         super(WebExperiment, self).before_run(device, path, run)
+        device.shell('logcat -c')
+        print('Logcat cleared')
         browser = args[0]
         browser.start(device)
         time.sleep(5)

--- a/example/batterystats/aggregation.py
+++ b/example/batterystats/aggregation.py
@@ -80,4 +80,4 @@ def main(device, output_root):
 
 if __name__ == '__main__':
     if len(sys.argv) == 2:
-        main(sys.argv[1])
+        main(None, sys.argv[1])

--- a/example/batterystats/aggregation.py
+++ b/example/batterystats/aggregation.py
@@ -59,7 +59,7 @@ def aggregate(data_dir):
                 row.update(aggregate_android(os.path.join(subject_dir, 'android')))
             if os.path.isdir(os.path.join(subject_dir, 'trepn')):
                 row.update(aggregate_trepn(os.path.join(subject_dir, 'trepn')))
-            rows.append(row)
+            rows.append(row.copy())
     return rows
 
 

--- a/example/native/aggregation.py
+++ b/example/native/aggregation.py
@@ -80,4 +80,4 @@ def main(device, output_root):
 
 if __name__ == '__main__':
     if len(sys.argv) == 2:
-        main(sys.argv[1])
+        main(None, sys.argv[1])

--- a/example/native/aggregation.py
+++ b/example/native/aggregation.py
@@ -59,7 +59,7 @@ def aggregate(data_dir):
                 row.update(aggregate_android(os.path.join(subject_dir, 'android')))
             if os.path.isdir(os.path.join(subject_dir, 'trepn')):
                 row.update(aggregate_trepn(os.path.join(subject_dir, 'trepn')))
-            rows.append(row)
+            rows.append(row.copy())
     return rows
 
 

--- a/example/web/aggregation.py
+++ b/example/web/aggregation.py
@@ -13,7 +13,7 @@ def list_subdir(a_dir):
 
 def aggregate_android(logs_dir):
     def add_row(accum, new):
-        row = {k: v + float(new[k]) for k, v in accum.items() if k != 'count'}
+        row = {k: v + float(new[k]) for k, v in accum.items() if k not in ['Component', 'count']}
         count = accum['count'] + 1
         return dict(row, **{'count': count})
 

--- a/example/web/aggregation.py
+++ b/example/web/aggregation.py
@@ -62,7 +62,8 @@ def aggregate(data_dir):
                     row.update(aggregate_android(os.path.join(browser_dir, 'android')))
                 if os.path.isdir(os.path.join(browser_dir, 'trepn')):
                     row.update(aggregate_trepn(os.path.join(browser_dir, 'trepn')))
-                rows.append(row)
+                rows.append(row.copy())
+
     return rows
 
 

--- a/example/web/aggregation.py
+++ b/example/web/aggregation.py
@@ -84,4 +84,4 @@ def main(device, output_root):
 
 if __name__ == '__main__':
     if len(sys.argv) == 2:
-        main(sys.argv[1])
+        main(None, sys.argv[1])


### PR DESCRIPTION
Here are a few fixes for some bugs I had with WebExperiment and the Batterystatus Profiler.

https://github.com/S2-group/android-runner/pull/1/commits/e1543751deaa04968d1f451438dc4ede0a8de538 should fix the bug mentioned here: https://canvas.vu.nl/courses/36343/discussion_topics/90615 by not clearing the logs after starting the browser.

https://github.com/S2-group/android-runner/commit/380b8671cebb46df2677c757ddd384b418141ade was necessary for me too. It's probably because the script is written for a different version of either systrace.py or system-image. The following lines are printed from my systrace, on which the pattern matching fails
```
(empty)
All UID cpu time reads since the later of device start or stats reset: 12
UIDs removed since the later of device start or stats reset: 2
```
`sdkmanager --list` prints
```
Installed packages:
  Path                                             | Version | Description                                | Location
  -------                                          | ------- | -------                                    | -------
  build-tools;28.0.2                               | 28.0.2  | Android SDK Build-Tools 28.0.2             | build-tools/28.0.2/
  emulator                                         | 27.3.10 | Android Emulator                           | emulator/
  patcher;v4                                       | 1       | SDK Patch Applier v4                       | patcher/v4/
  platform-tools                                   | 28.0.1  | Android SDK Platform-Tools                 | platform-tools/
  system-images;android-25;google_apis;armeabi-v7a | 14      | Google APIs ARM EABI v7a System Image      | system-images/android-25/google_apis/armeabi-v7a/
  system-images;android-28;google_apis;x86_64      | 5       | Google APIs Intel x86 Atom_64 System Image | system-images/android-28/google_apis/x86_64/
  tools                                            | 26.1.1  | Android SDK Tools 26.1.1                   | tools/

```