### PR TITLE
Implement support for running vanilla MonkeyRunner scripts

### DIFF
--- a/ExperimentRunner/MonkeyRunner.py
+++ b/ExperimentRunner/MonkeyRunner.py
@@ -1,0 +1,40 @@
+import subprocess
+
+from ExperimentRunner.Script import Script
+
+
+class MonkeyRunner(Script):
+    """
+    Subclass of `Script` for running MonkeyRunner scripts directly.
+
+    As opposed to `MonkeyReplay`, it runs the scripts directly using MonkeyRunner.
+    Thanks to that it's not necessary to go through a layer of indirection in the
+    form of JSON files and a custom runner. This results in higher flexibility and
+    greater control.
+
+    Usage:
+    1. Create a script runnable by MonkeyRunner.
+    2. Add it to the config file with the type "monkeyrunner".
+
+    Important!
+    The script has to be directly runnable by MonkeyRunner. It means that:
+    - it has to create an instance of `MonkeyDevice` explicitly in the script,
+    - all operations are supposed to be invoked on this instance,
+    - there has to be module-level code running the operations,
+    - it has to follow any other restrictions specified in the docs.
+
+    Docs and examples: https://developer.android.com/studio/test/monkeyrunner/
+    """
+
+    def __init__(self, path, timeout=0, logcat_regex=None, monkeyrunner_path='monkeyrunner'):
+        super(MonkeyRunner, self).__init__(path, timeout, logcat_regex)
+        self.monkeyrunner_path = monkeyrunner_path
+
+    def execute_script(self, device, *args, **kwargs):
+        """
+        Run the MonkeyRunner script.
+
+        Returns the return value returned by MonkeyRunner.
+        """
+        super(MonkeyRunner, self).execute_script(device, *args, **kwargs)
+        return subprocess.call([self.monkeyrunner_path, self.path])

--- a/ExperimentRunner/Scripts.py
+++ b/ExperimentRunner/Scripts.py
@@ -1,10 +1,11 @@
 import logging
 import os.path as op
 
-from util import ConfigError
-from Python2 import Python2
-from MonkeyReplay import MonkeyReplay
 import paths
+from MonkeyReplay import MonkeyReplay
+from MonkeyRunner import MonkeyRunner
+from Python2 import Python2
+from util import ConfigError
 
 
 class Scripts(object):
@@ -21,13 +22,17 @@ class Scripts(object):
                 path = op.join(paths.CONFIG_DIR, s['path'])
                 timeout = s.get('timeout', 0)
                 logcat_regex = s.get('logcat_regex', None)
+
                 if s['type'] == 'python2':
-                    self.scripts[name].append(Python2(path, timeout, logcat_regex))
+                    script = Python2(path, timeout, logcat_regex)
                 elif s['type'] == 'monkeyreplay':
-                    self.scripts[name].append(
-                        MonkeyReplay(path, timeout, logcat_regex, monkeyrunner_path=monkeyrunner_path))
+                    script = MonkeyReplay(path, timeout, logcat_regex, monkeyrunner_path)
+                elif s['type'] == 'monkeyrunner':
+                    script = MonkeyRunner(path, timeout, logcat_regex, monkeyrunner_path)
                 else:
-                    raise ConfigError('Unknown script type')
+                    raise ConfigError('Unknown script type: {}'.format(s['type']))
+
+                self.scripts[name].append(script)
 
     def run(self, name, device, *args, **kwargs):
         self.logger.debug('Running hook {} on device {}\nargs: {}\nkwargs: {}'.format(name, device, args, kwargs))


### PR DESCRIPTION
I found `MonkeyReplay` unnecessarily complicated, so I implemented a simpler way of running MonkeyRunner scripts called just `MonkeyRunner`.

From the docstring of `MonkeyRunner`:

> As opposed to `MonkeyReplay`, it runs the scripts directly using MonkeyRunner.
Thanks to that it's not necessary to go through a layer of indirection in the
form of JSON files and a custom runner. This results in higher flexibility and
greater control.
>
> Usage:
    1. Create a script runnable by MonkeyRunner.
    2. Add it to the config file with the type "monkeyrunner".
>
> Important!
> The script has to be directly runnable by MonkeyRunner. It means that:
    - it has to create an instance of `MonkeyDevice` explicitly in the script,
    - all operations are supposed to be invoked on this instance,
    - there has to be module-level code running the operations,
    - it has to follow any other restrictions specified in the docs.