### PR TITLE
Some fixes about BatteryStats.py

### DIFF
--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -80,10 +80,11 @@ class Batterystats(Profiler):
 
         # Estimate total consumption
         # charge is given in mAh
+	# volt is given in mV
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
-        energy_consumed_Wh = float(charge) * float(volt) / 1000.0 #volt are in millivolt, charge in mAh, here ther's a division by 1000 => Wh is wrong, it is in mWh
-        energy_consumed_J = energy_consumed_Wh * 3600.0 #J is wrong, is in mJ
+        energy_consumed_Wh = float(charge) * float(volt) / 10000.0
+        energy_consumed_J = energy_consumed_Wh * 3600.0
 
         # Wait for Systrace file finalisation before parsing
         sysproc.wait()

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -82,8 +82,8 @@ class Batterystats(Profiler):
         # charge is given in mAh
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
-        energy_consumed_Wh = float(charge) * float(volt) / 1000.0
-        energy_consumed_J = energy_consumed_Wh * 3600.0
+        energy_consumed_Wh = float(charge) * float(volt) / 1000.0 #volt are in millivolt, charge in mAh, here ther's a division by 1000 => Wh is wrong, it is in mWh
+        energy_consumed_J = energy_consumed_Wh * 3600.0 #J is wrong, is in mJ
 
         # Wait for Systrace file finalisation before parsing
         sysproc.wait()

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -84,7 +84,7 @@ class Batterystats(Profiler):
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
         energy_consumed_Wh = float(charge) * float(volt) / 10000.0
-        energy_consumed_J = energy_consumed_Wh * 3600.0
+        energy_consumed_J = energy_consumed_Wh / 3600.0
 
         # Wait for Systrace file finalisation before parsing
         sysproc.wait()

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -80,7 +80,6 @@ class Batterystats(Profiler):
 
         # Estimate total consumption
         # charge is given in mAh
-	# volt is given in mV
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
         energy_consumed_Wh = float(charge) * float(volt) / 10000.0

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -82,8 +82,8 @@ class Batterystats(Profiler):
         # charge is given in mAh
         charge = device.shell('dumpsys batterystats | grep "Computed drain:"').split(',')[1].split(':')[1]
         volt = device.shell('dumpsys batterystats | grep "volt="').split('volt=')[1].split()[0]
-        energy_consumed_Wh = float(charge) * float(volt) / 10000.0
-        energy_consumed_J = energy_consumed_Wh / 3600.0
+        energy_consumed_Wh = float(charge) * float(volt) / 1000000.0
+        energy_consumed_J = energy_consumed_Wh * 3600.0
 
         # Wait for Systrace file finalisation before parsing
         sysproc.wait()

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -144,7 +144,8 @@ class Batterystats(Profiler):
             count = accum['count'] + 1
             return dict(row, **{'count': count})
 #FIX
-        runs = [{'Joule calculated': 0.0}]
+        runs = []
+	runs_total = dict()
         for run_file in [f for f in os.listdir(logs_dir) if os.path.isfile(os.path.join(logs_dir, f))]:
             if ('Joule' in run_file) and joules:
                 with open(os.path.join(logs_dir, run_file), 'rb') as run:
@@ -152,7 +153,7 @@ class Batterystats(Profiler):
                     init = dict({fn: 0 for fn in reader.fieldnames if fn != 'datetime'}, **{'count': 0})
                     run_total = reduce(add_row, reader, init)
                     runs.append({k: v / run_total['count'] for k, v in run_total.items() if k != 'count'})
-        runs_total = reduce(lambda x, y: {k: v + y[k] for k, v in x.items()},runs)
+        	runs_total = reduce(lambda x, y: {k: v + y[k] for k, v in x.items()},runs)
         return OrderedDict(
             sorted({'batterystats_' + k: v / len(runs) for k, v in runs_total.items()}.items(), key=lambda x: x[0]))
 


### PR DESCRIPTION
line 24: self.paths.CONFIG_DIR is wrong because you cannot access to a dictionary attribute like that, correct syntax is self.paths["CONFIG_DIR"]
line 65: we tried the command produced there (systrace with its parameters) but when you try to open the report file generated it return an error about the system clock; finally, deleting from the command string the -b parameter (buffer) it goes well
line 100: the "open mode" of the file must be w+
line 130: rows = self.aggregate(data_dir) -> aggregate procedure doesn't exist, we presume that the correct one is aggregate_final
line 146 (the tough one): at line 154 reduce doesn't accept an empty set(runs), so we inizialized runs_total before like a dir() and reduce only if run is not empty.
 Moreover at line 148 run_file.contains('Joule') is wrong because unicode object has no method contains, so we replaced it with ('Joule' in run_file).
Ivano told me to open a pull request to check if these changes are correct.