### PR TITLE
Implemented minor functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/thijmen/.virtualenvs/default/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/thijmen/.virtualenvs/default/bin/python"
-}

--- a/ExperimentRunner/Devices.py
+++ b/ExperimentRunner/Devices.py
@@ -9,9 +9,12 @@ from util import ConfigError, load_json
 
 
 class Devices:
-    def __init__(self, devices, adb_path='adb'):
+    def __init__(self, devices, adb_path='adb', devices_spec=None):
+        if devices_spec is None:
+            devices_spec = op.join(ROOT_DIR, 'devices.json')
+
         Adb.setup(adb_path)
-        mapping_file = load_json(op.join(ROOT_DIR, 'devices.json'))
+        mapping_file = load_json(devices_spec)
         self._device_map = {n: mapping_file.get(n, None) for n in devices}
         for name, device_id in self._device_map.items():
             if not device_id:

--- a/ExperimentRunner/Experiment.py
+++ b/ExperimentRunner/Experiment.py
@@ -22,7 +22,7 @@ class Experiment(object):
         if 'devices' not in config:
             raise ConfigError('"device" is required in the configuration')
         adb_path = config.get('adb_path', 'adb')
-        self.devices = Devices(config['devices'], adb_path=adb_path)
+        self.devices = Devices(config['devices'], adb_path=adb_path, devices_spec=config.get('devices_spec'))
         self.replications = Tests.is_integer(config.get('replications', 1))
         self.paths = config.get('paths', [])
         self.profilers = Profilers(config.get('profilers', {}))

--- a/ExperimentRunner/Experiment.py
+++ b/ExperimentRunner/Experiment.py
@@ -25,7 +25,7 @@ class Experiment(object):
         self.devices = Devices(config['devices'], adb_path=adb_path, devices_spec=config.get('devices_spec'))
         self.replications = Tests.is_integer(config.get('replications', 1))
         self.paths = config.get('paths', [])
-        self.profilers = Profilers(config.get('profilers', {}))
+        self.profilers = Profilers(config.get('profilers', {}), config)
         monkeyrunner_path = config.get('monkeyrunner_path', 'monkeyrunner')
         self.scripts = Scripts(config.get('scripts', {}), monkeyrunner_path=monkeyrunner_path)
         self.time_between_run = Tests.is_integer(config.get('time_between_run', 0))

--- a/ExperimentRunner/ExperimentFactory.py
+++ b/ExperimentRunner/ExperimentFactory.py
@@ -18,11 +18,18 @@ class ExperimentFactory(object):
         pass
 
     @staticmethod
-    def from_json(path, progress):
+    def from_json(path, progress, args={}):
         """Returns an Experiment object from a JSON configuration"""
         logger.info(path)
         shutil.copy(path, op.join(paths.OUTPUT_DIR, 'config.json'))
         config = util.load_json(path)
+
+        if "test" in args and args["test"]:
+            config['duration'] = 1000
+            config['time_between_run'] = 1000
+            config['replications'] = 1
+            print("Test mode enabled, duration and time between run changed to one second and replications to 1.")
+
         experiment_type = config['type']
         if experiment_type == 'plugintest':
             return PluginTests(config)

--- a/ExperimentRunner/ExperimentFactory.py
+++ b/ExperimentRunner/ExperimentFactory.py
@@ -26,9 +26,9 @@ class ExperimentFactory(object):
 
         if "test" in args and args["test"]:
             config['duration'] = 6000
-            config['time_between_run'] = 100
+            config['time_between_run'] = 1000
             config['replications'] = 1
-            print("Test mode enabled, duration and time between run changed to one second and replications to 1.")
+            print("Test mode enabled (dureation: %d, time_between_run: %d, replications: %d)" %(config['duration'], config['time_between_run'], config['replications'] ))
 
         experiment_type = config['type']
         if experiment_type == 'plugintest':

--- a/ExperimentRunner/ExperimentFactory.py
+++ b/ExperimentRunner/ExperimentFactory.py
@@ -25,8 +25,8 @@ class ExperimentFactory(object):
         config = util.load_json(path)
 
         if "test" in args and args["test"]:
-            config['duration'] = 1000
-            config['time_between_run'] = 1000
+            config['duration'] = 6000
+            config['time_between_run'] = 100
             config['replications'] = 1
             print("Test mode enabled, duration and time between run changed to one second and replications to 1.")
 

--- a/ExperimentRunner/ExperimentFactory.py
+++ b/ExperimentRunner/ExperimentFactory.py
@@ -24,8 +24,8 @@ class ExperimentFactory(object):
         shutil.copy(path, op.join(paths.OUTPUT_DIR, 'config.json'))
         config = util.load_json(path)
 
-        if "test" in args and args["test"]:
-            config['duration'] = 6000
+        if "test" in args and args["test"] > 0:
+            config['duration'] = args["test"]
             config['time_between_run'] = 1000
             config['replications'] = 1
             print("Test mode enabled (dureation: %d, time_between_run: %d, replications: %d)" %(config['duration'], config['time_between_run'], config['replications'] ))

--- a/ExperimentRunner/PluginHandler.py
+++ b/ExperimentRunner/PluginHandler.py
@@ -10,7 +10,7 @@ from util import makedirs
 
 
 class PluginHandler(object):
-    def __init__(self, name, params):
+    def __init__(self, name, params, full_config={}):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.pluginParams = params
         self.name = name
@@ -25,7 +25,7 @@ class PluginHandler(object):
             plugin_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'Plugins')
             self.plugin_source = self.plugin_base.make_plugin_source(searchpath=[plugin_path])
             self.pluginModule = self.plugin_source.load_plugin(self.moduleName)
-            self.currentProfiler = getattr(self.pluginModule, self.moduleName)(params, self.paths)
+            self.currentProfiler = getattr(self.pluginModule, self.moduleName)(params, self.paths, full_config)
             self.name = self.name_lower
         else:
             plugin_path = os.path.join(paths.CONFIG_DIR, 'Plugins')
@@ -34,7 +34,7 @@ class PluginHandler(object):
                     plugin_path, 'Profiler.py'))
                 self.plugin_source = self.plugin_base.make_plugin_source(searchpath=[plugin_path])
                 self.pluginModule = self.plugin_source.load_plugin(self.name)
-                self.currentProfiler = getattr(self.pluginModule, self.name)(params, self.paths)
+                self.currentProfiler = getattr(self.pluginModule, self.name)(params, self.paths, full_config)
             else:
                 raise ImportError
         self.logger.debug('%s: Initialized' % self.name)

--- a/ExperimentRunner/Plugins/Android.py
+++ b/ExperimentRunner/Plugins/Android.py
@@ -14,7 +14,7 @@ class ConfigError(Exception):
 
 
 class Android(Profiler):
-    def __init__(self, config, paths):
+    def __init__(self, config, paths, full_config={}):
         super(Android, self).__init__(config, paths)
         self.output_dir = ''
         self.paths = paths

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -134,7 +134,11 @@ class Batterystats(Profiler):
         self.pull_logcat(device)
         batterystats_results = self.get_batterystats_results(device)
         energy_consumed_j = self.get_consumed_joules(device)
-        systrace_results = self.get_systrace_results(device)
+        try:
+            systrace_results = self.get_systrace_results(device)
+        except Exception as e:
+            print("Systrace results parsing failed... (%s)"%(str(e)))
+            systrace_results = []
         self.write_results(batterystats_results, systrace_results, energy_consumed_j)
         self.cleanup_logs()
 

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -22,6 +22,7 @@ class Batterystats(Profiler):
         self.profile = False
         self.cleanup = config.get('cleanup')
 
+        print(config)
         # "config" only passes the fields under "profilers", so config.json is loaded again for the fields below
         # FIX
         config_f = load_json(op.join(self.paths["CONFIG_DIR"], self.paths['ORIGINAL_CONFIG_DIR']))

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -22,6 +22,10 @@ class Batterystats(Profiler):
         self.profile = False
         self.cleanup = config.get('cleanup')
 
+        # Compatibility
+        if 'type' not in full_config:
+            full_config = load_json(op.join(self.paths["CONFIG_DIR"], self.paths['ORIGINAL_CONFIG_DIR']))
+
         self.type = full_config['type']
         self.systrace = full_config.get('systrace_path', 'systrace')
         self.powerprofile = full_config['powerprofile_path']

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -15,23 +15,19 @@ from Profiler import Profiler
 
 class Batterystats(Profiler):
 
-    def __init__(self, config, paths):
+    def __init__(self, config, paths, full_config={}):
         super(Batterystats, self).__init__(config, paths)
         self.output_dir = ''
         self.paths = paths
         self.profile = False
         self.cleanup = config.get('cleanup')
 
-        print(config)
-        # "config" only passes the fields under "profilers", so config.json is loaded again for the fields below
-        # FIX
-        config_f = load_json(op.join(self.paths["CONFIG_DIR"], self.paths['ORIGINAL_CONFIG_DIR']))
-        self.type = config_f['type']
-        self.systrace = config_f.get('systrace_path', 'systrace')
-        self.powerprofile = config_f['powerprofile_path']
-        self.duration = self.is_integer(config_f.get('duration', 0)) / 1000
+        self.type = full_config['type']
+        self.systrace = full_config.get('systrace_path', 'systrace')
+        self.powerprofile = full_config['powerprofile_path']
+        self.duration = self.is_integer(full_config.get('duration', 0)) / 1000
         if self.type == 'web':
-            self.browsers = [BrowserFactory.get_browser(b)(config_f) for b in config_f.get('browsers', ['chrome'])]
+            self.browsers = [BrowserFactory.get_browser(b)(full_config) for b in full_config.get('browsers', ['chrome'])]
 
     # noinspection PyGlobalUndefined
     def start_profiling(self, device, **kwargs):

--- a/ExperimentRunner/Plugins/Batterystats.py
+++ b/ExperimentRunner/Plugins/Batterystats.py
@@ -6,6 +6,7 @@ import os.path as op
 import subprocess
 import time
 from collections import OrderedDict
+from util import load_json
 
 import BatterystatsParser
 from ExperimentRunner.BrowserFactory import BrowserFactory
@@ -23,7 +24,7 @@ class Batterystats(Profiler):
 
         # "config" only passes the fields under "profilers", so config.json is loaded again for the fields below
         # FIX
-        config_f = self.load_json(op.join(self.paths["CONFIG_DIR"], self.paths['ORIGINAL_CONFIG_DIR']))
+        config_f = load_json(op.join(self.paths["CONFIG_DIR"], self.paths['ORIGINAL_CONFIG_DIR']))
         self.type = config_f['type']
         self.systrace = config_f.get('systrace_path', 'systrace')
         self.powerprofile = config_f['powerprofile_path']
@@ -235,21 +236,6 @@ class Batterystats(Profiler):
         if number < minimum:
             raise ConfigError('%s should be equal or larger than %i' % (number, minimum))
         return number
-
-    @staticmethod
-    def load_json(path):
-        """Load a JSON file from path, and returns an ordered dictionary or throws exceptions on formatting errors"""
-        try:
-            with open(path, 'r') as f:
-                try:
-                    return json.loads(f.read(), object_pairs_hook=OrderedDict)
-                except ValueError:
-                    raise FileFormatError(path)
-        except IOError as e:
-            if e.errno == errno.ENOENT:
-                raise FileNotFoundError(path)
-            else:
-                raise e
 
 
 class FileNotFoundError(Exception):

--- a/ExperimentRunner/Plugins/Trepn.py
+++ b/ExperimentRunner/Plugins/Trepn.py
@@ -5,6 +5,7 @@ import os
 import os.path as op
 import time
 from collections import OrderedDict
+from util import load_json
 
 import lxml.etree as et
 
@@ -44,7 +45,7 @@ class Trepn(Profiler):
 
         datapoints_file = et.parse(op.join(current_dir, 'trepn/data_points.xml'))
         dp_root = datapoints_file.getroot()
-        data_points_dict = self.load_json(op.join(current_dir, 'trepn/data_points.json'))
+        data_points_dict = load_json(op.join(current_dir, 'trepn/data_points.json'))
         for dp in params['data_points']:
             dp = str(data_points_dict[dp])
             self.data_points.append(dp)
@@ -250,22 +251,6 @@ class Trepn(Profiler):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-
-    @staticmethod
-    def load_json(path):
-        """Load a JSON file from path, and returns an ordered dictionary or throws exceptions on formatting errors"""
-        try:
-            with open(path, 'r') as f:
-                try:
-                    return json.loads(f.read(), object_pairs_hook=OrderedDict)
-                except ValueError:
-                    raise FileFormatError(path)
-        except IOError as e:
-            if e.errno == errno.ENOENT:
-                raise FileNotFoundError(path)
-            else:
-                raise e
-
 
 class FileNotFoundError(Exception):
     def __init__(self, filename):

--- a/ExperimentRunner/Plugins/Trepn.py
+++ b/ExperimentRunner/Plugins/Trepn.py
@@ -18,7 +18,7 @@ class Trepn(Profiler):
     def dependencies(self):
         return ['com.quicinc.trepn']
 
-    def __init__(self, config, paths):
+    def __init__(self, config, paths, full_config={}):
         super(Trepn, self).__init__(config, paths)
         self.output_dir = ''
         self.paths = paths

--- a/ExperimentRunner/Profilers.py
+++ b/ExperimentRunner/Profilers.py
@@ -12,7 +12,7 @@ class Profilers(object):
         self.loaded_devices = []
         for name, params in config.items():
             try:
-                self.profilers.append(PluginHandler(name, params))
+                self.profilers.append(PluginHandler(name, params, config))
             except ImportError:
                 self.logger.error('Cannot import %s' % name)
                 raise

--- a/ExperimentRunner/Profilers.py
+++ b/ExperimentRunner/Profilers.py
@@ -6,13 +6,13 @@ from PluginHandler import PluginHandler
 
 class Profilers(object):
 
-    def __init__(self, config):
+    def __init__(self, config, full_config={}):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.profilers = []
         self.loaded_devices = []
         for name, params in config.items():
             try:
-                self.profilers.append(PluginHandler(name, params, config))
+                self.profilers.append(PluginHandler(name, params, full_config))
             except ImportError:
                 self.logger.error('Cannot import %s' % name)
                 raise

--- a/ExperimentRunner/Script.py
+++ b/ExperimentRunner/Script.py
@@ -49,7 +49,7 @@ class Script(object):
         """Execute the script with respect to the termination conditions"""
         # https://stackoverflow.com/a/6286343
         with script_timeout(seconds=self.timeout):
-            processes = []
+            processes = [] # type:mp.Process[]
             try:
                 queue = mp.Queue()
                 processes.append(mp.Process(target=self.mp_run, args=(queue, device,) + args, kwargs=kwargs))
@@ -57,6 +57,9 @@ class Script(object):
                     processes.append(mp.Process(target=self.mp_logcat_regex, args=(queue, device, self.logcat_event)))
                 for p in processes:
                     p.start()
+                for p in processes:
+                    p.join(self.timeout)
+                        
                 result = queue.get()
                 if isinstance(result, tuple):
                     name = result[0].__class__.__name__

--- a/ExperimentRunner/Script.py
+++ b/ExperimentRunner/Script.py
@@ -49,7 +49,7 @@ class Script(object):
         """Execute the script with respect to the termination conditions"""
         # https://stackoverflow.com/a/6286343
         with script_timeout(seconds=self.timeout):
-            processes = [] # type:mp.Process[]
+            processes = []
             try:
                 queue = mp.Queue()
                 processes.append(mp.Process(target=self.mp_run, args=(queue, device,) + args, kwargs=kwargs))
@@ -59,7 +59,7 @@ class Script(object):
                     p.start()
                 for p in processes:
                     p.join(self.timeout)
-                        
+
                 result = queue.get()
                 if isinstance(result, tuple):
                     name = result[0].__class__.__name__

--- a/ExperimentRunner/util.py
+++ b/ExperimentRunner/util.py
@@ -18,12 +18,26 @@ class FileFormatError(Exception):
     pass
 
 
+def expand_paths(config):
+    if isinstance(config, dict):
+        for key in config:
+            config[key] = expand_paths(config[key])
+    elif isinstance(config, list):
+        for i in range(len(config)):
+            config[i] = expand_paths(config[i])
+    elif isinstance(config, unicode) or isinstance(config, str):
+        if config.startswith('~'):
+            config = os.path.expanduser(config)
+
+    return config
+                
+
 def load_json(path):
     """Load a JSON file from path, and returns an ordered dictionary or throws exceptions on formatting errors"""
     try:
         with open(path, 'r') as f:
             try:
-                return json.loads(f.read(), object_pairs_hook=OrderedDict)
+                return expand_paths(json.loads(f.read(), object_pairs_hook=OrderedDict))
             except ValueError:
                 raise FileFormatError(path)
     except IOError as e:

--- a/ExperimentRunner/util.py
+++ b/ExperimentRunner/util.py
@@ -37,7 +37,9 @@ def load_json(path):
     try:
         with open(path, 'r') as f:
             try:
-                return expand_paths(json.loads(f.read(), object_pairs_hook=OrderedDict))
+                config = expand_paths(json.loads(f.read(), object_pairs_hook=OrderedDict))
+                if os.getenv("DEBUG", False): print(config)
+                return config
             except ValueError:
                 raise FileFormatError(path)
     except IOError as e:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,26 @@ python android_runner your_config.json
 Example configuration files can be found in the subdirectories of the `example` directory.
 
 ## Structure
+### Paths
+To prevent user specific paths inside of `your_config.json` replace your user subpath with `~/`. 
+
+For example: `/home/user/Android/Sdk/platform-tools/systrace/systrace.py` becomes `~/Android/Sdk/platform-tools/systrace/systrace.py`.
+
 ### devices.json
 A JSON config that maps devices names to their ADB ids for easy reference in config files.
+
+Specify **device_spec** inside of your config to specify a devices.json outside of the android-runner repository. For example:
+```
+{
+  ....
+  "type": "native",
+  "devices_spec": "~/experiments/devices.json",
+  "devices": {
+    "nexus6p": {}
+  },
+  ...
+}
+```
 
 ### Experiment Configuration
 Below is a reference to the fields for the experiment configuration. It is not always updated.
@@ -212,6 +230,13 @@ To test your own profiler, you can make use of the 'plugintest' experiment type 
 In case of an error or a user abort during experiment execution, it is possible to continue the experiment if desired. This is possible by using a ```--progress``` tag with the starting command. For example:
 
 ```python android_runner your_config.json --progress path/to/progress.xml```
+
+## Test runs
+In order to perform test runs with `your_config.json` add the `--test N` flag to the starting command, where `N` is the desired duration of the test run. For example:
+
+```python android_runner your_config.json --test N```
+
+This will override the `time_between_run`, `duration` and `replications` specified in `your_config.json` to `1000`, `N` and `1` respectively. This allows you to perform quick tests of your configs without needing to change anything within the config file itself.
 
 ## Detailed documentation
 The original thesis can be found here:

--- a/__main__.py
+++ b/__main__.py
@@ -23,7 +23,7 @@ def main():
         progress_file = ' No progress file created'
 
     try:
-        experiment = ExperimentFactory.from_json(config_file, progress)
+        experiment = ExperimentFactory.from_json(config_file, progress, args)
         progress_file = experiment.get_progress_xml_file()
         experiment.start()
     except Exception, e:
@@ -53,6 +53,7 @@ def parse_arguments(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('file')
     parser.add_argument('--progress', default=argparse.SUPPRESS)
+    parser.add_argument('--test', action='store_true')
     return vars(parser.parse_args(args))
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -16,7 +16,7 @@ def main():
     config_file = op.abspath(args['file'])
     setup_paths(config_file, log_dir)
     logger = setup_logger(log_dir)
-
+    print(args)
     try:
         progress_file = progress.get_progress_xml_file()
     except Exception:
@@ -53,7 +53,7 @@ def parse_arguments(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('file')
     parser.add_argument('--progress', default=argparse.SUPPRESS)
-    parser.add_argument('--test', action='store_true')
+    parser.add_argument('--test', type=int, default=0)
     return vars(parser.parse_args(args))
 
 

--- a/__main__.py
+++ b/__main__.py
@@ -16,7 +16,7 @@ def main():
     config_file = op.abspath(args['file'])
     setup_paths(config_file, log_dir)
     logger = setup_logger(log_dir)
-    print(args)
+    
     try:
         progress_file = progress.get_progress_xml_file()
     except Exception:


### PR DESCRIPTION
* Added '--test N' flag which overrides duration, time between run and replications to allow for easy test runs.
* Removed duplicated code
* Allow for user expansion inside of the config files (e.g. ~/android-runner becomes /home/user/android-runner).
* Added property inside of config file that allows devices.json to live outside of the android-runner repository ('device_spec')
* Updated README to reflect the new functionality