### PR TITLE
Adb cleanup

### DIFF
--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -144,7 +144,7 @@ def logcat(device_id, regex=None):
 
 
 def reset(cmd):
-    if cmd == "True":
+    if cmd:
         logger.info('Shutting down adb...')
         sleep(1)
         adb.kill_server()

--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -1,6 +1,7 @@
 import logging
 import os.path as op
 from .util import ConfigError
+from time import sleep
 
 from .pyand import ADB
 
@@ -142,13 +143,12 @@ def logcat(device_id, regex=None):
     return adb.get_logcat(lcfilter=params)
 
 
-def cleanup(cmd):
-    from time import sleep
-    if cmd == "restart":
+def reset(cmd):
+    if cmd == "True":
         logger.info('Shutting down adb...')
         sleep(1)
         adb.kill_server()
-        sleep(4)
+        sleep(2)
         logger.info('Restarting adb...')
         adb.get_devices()
         sleep(10)

--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -141,10 +141,6 @@ def logcat(device_id, regex=None):
     adb.set_target_by_name(device_id)
     return adb.get_logcat(lcfilter=params)
 
-def clean(cmd):
-    if(cmd == "restart"):
-        restart()
-
 
 def restart():
     from time import sleep

--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -1,6 +1,5 @@
 import logging
 import os.path as op
-from .util import ConfigError
 from time import sleep
 
 from .pyand import ADB

--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -1,5 +1,6 @@
 import logging
 import os.path as op
+from .util import ConfigError
 
 from .pyand import ADB
 
@@ -139,3 +140,18 @@ def logcat(device_id, regex=None):
         params += ' -e %s' % regex
     adb.set_target_by_name(device_id)
     return adb.get_logcat(lcfilter=params)
+
+def clean(cmd):
+    if(cmd == "restart"):
+        restart()
+
+
+def restart():
+    from time import sleep
+    logger.info('Shutting down adb...')
+    sleep(1)
+    adb.kill_server()
+    sleep(4)
+    logger.info('Restarting adb...')
+    adb.get_devices()
+    sleep(10)

--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -36,7 +36,7 @@ def connect(device_id):
         raise ConnectionError('No devices are connected')
     logger.debug('Device list:\n%s' % device_list)
     if device_id not in list(device_list.values()):
-        raise ConnectionError('%s: Device can not connected' % device_id)
+        raise ConnectionError('%s: Device not recognized' % device_id)
 
 
 def shell_su(device_id, cmd):
@@ -142,12 +142,13 @@ def logcat(device_id, regex=None):
     return adb.get_logcat(lcfilter=params)
 
 
-def restart():
+def cleanup(cmd):
     from time import sleep
-    logger.info('Shutting down adb...')
-    sleep(1)
-    adb.kill_server()
-    sleep(4)
-    logger.info('Restarting adb...')
-    adb.get_devices()
-    sleep(10)
+    if cmd == "restart":
+        logger.info('Shutting down adb...')
+        sleep(1)
+        adb.kill_server()
+        sleep(4)
+        logger.info('Restarting adb...')
+        adb.get_devices()
+        sleep(10)

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -29,8 +29,8 @@ class Experiment(object):
         self.profilers = Profilers(config.get('profilers', {}))
         monkeyrunner_path = config.get('monkeyrunner_path', 'monkeyrunner')
         self.scripts = Scripts(config.get('scripts', {}), monkeyrunner_path=monkeyrunner_path)
-        self.adb_cleanup_per_run = config.get('adb_cleanup_per_run', False)
-        Tests.is_valid_option(self.adb_cleanup_per_run, valid_options=["restart"])
+        self.reset_adb_among_runs = config.get('reset_adb_among_runs', "False")
+        Tests.is_valid_option(self.reset_adb_among_runs, valid_options=["True", "False"])
         self.time_between_run = Tests.is_integer(config.get('time_between_run', 0))
         Tests.check_dependencies(self.devices, self.profilers.dependencies())
         self.output_root = paths.OUTPUT_DIR
@@ -211,8 +211,7 @@ class Experiment(object):
         """Hook executed after a run"""
         self.scripts.run('after_run', device, *args, **kwargs)
         self.profilers.collect_results(device)
-        if self.adb_cleanup_per_run:
-            Adb.cleanup(self.adb_cleanup_per_run)
+        Adb.reset(self.reset_adb_among_runs)
         self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)
 

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -211,8 +211,8 @@ class Experiment(object):
         """Hook executed after a run"""
         self.scripts.run('after_run', device, *args, **kwargs)
         self.profilers.collect_results(device)
-        if self.adb_cleanup_per_run == "restart":
-            Adb.restart()
+        if self.adb_cleanup_per_run:
+            Adb.cleanup(self.adb_cleanup_per_run)
         self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)
 

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -20,6 +20,7 @@ class Experiment(object):
         self.progress = progress
         self.basedir = None
         self.random = config.get('randomization', False)
+        Tests.is_valid_option(self.random, valid_options=[True, False])
         if 'devices' not in config:
             raise ConfigError('"device" is required in the configuration')
         adb_path = config.get('adb_path', 'adb')
@@ -29,8 +30,8 @@ class Experiment(object):
         self.profilers = Profilers(config.get('profilers', {}))
         monkeyrunner_path = config.get('monkeyrunner_path', 'monkeyrunner')
         self.scripts = Scripts(config.get('scripts', {}), monkeyrunner_path=monkeyrunner_path)
-        self.reset_adb_among_runs = config.get('reset_adb_among_runs', "False")
-        Tests.is_valid_option(self.reset_adb_among_runs, valid_options=["True", "False"])
+        self.reset_adb_among_runs = config.get('reset_adb_among_runs', False)
+        Tests.is_valid_option(self.reset_adb_among_runs, valid_options=[True, False])
         self.time_between_run = Tests.is_integer(config.get('time_between_run', 0))
         Tests.check_dependencies(self.devices, self.profilers.dependencies())
         self.output_root = paths.OUTPUT_DIR

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -216,7 +216,7 @@ class Experiment(object):
             Adb.adb.kill_server()
             time.sleep(4)
             self.logger.info('Restarting adb...')
-            Adb.adb.start_server()
+            Adb.adb.get_devices()
             time.sleep(10)
         self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -23,7 +23,7 @@ class Experiment(object):
             raise ConfigError('"device" is required in the configuration')
         adb_path = config.get('adb_path', 'adb')
         self.devices = Devices(config['devices'], adb_path=adb_path, devices_spec=config.get('devices_spec'))
-        self.replications = Tests.is_integer(config.get('replications', 1))
+        self.repetitions = Tests.is_integer(config.get('repetitions', 1))
         self.paths = config.get('paths', [])
         self.profilers = Profilers(config.get('profilers', {}))
         monkeyrunner_path = config.get('monkeyrunner_path', 'monkeyrunner')
@@ -183,7 +183,7 @@ class Experiment(object):
     def before_run(self, device, path, run, *args, **kwargs):
         """Hook executed before a run"""
         self.profilers.set_output()
-        self.logger.info('Run %s/%s of subject "%s" on %s' % (run, self.replications, path, device.name))
+        self.logger.info('Run %s/%s of subject "%s" on %s' % (run, self.repetitions, path, device.name))
         device.shell('logcat -c')
         self.logger.info('Logcat cleared')
         self.scripts.run('before_run', device, *args, **kwargs)

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -211,8 +211,8 @@ class Experiment(object):
         """Hook executed after a run"""
         self.scripts.run('after_run', device, *args, **kwargs)
         self.profilers.collect_results(device)
-        if self.adb_cleanup_per_run:
-            Adb.clean(self.adb_cleanup_per_run)
+        if self.adb_cleanup_per_run == "restart":
+            Adb.restart()
         self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)
 

--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -30,6 +30,7 @@ class Experiment(object):
         monkeyrunner_path = config.get('monkeyrunner_path', 'monkeyrunner')
         self.scripts = Scripts(config.get('scripts', {}), monkeyrunner_path=monkeyrunner_path)
         self.adb_cleanup_per_run = config.get('adb_cleanup_per_run', False)
+        Tests.is_valid_option(self.adb_cleanup_per_run, valid_options=["restart"])
         self.time_between_run = Tests.is_integer(config.get('time_between_run', 0))
         Tests.check_dependencies(self.devices, self.profilers.dependencies())
         self.output_root = paths.OUTPUT_DIR
@@ -210,14 +211,8 @@ class Experiment(object):
         """Hook executed after a run"""
         self.scripts.run('after_run', device, *args, **kwargs)
         self.profilers.collect_results(device)
-        if self.adb_cleanup_per_run == "restart":
-            self.logger.info('Shutting down adb...')
-            time.sleep(1)
-            Adb.adb.kill_server()
-            time.sleep(4)
-            self.logger.info('Restarting adb...')
-            Adb.adb.get_devices()
-            time.sleep(10)
+        if self.adb_cleanup_per_run:
+            Adb.clean(self.adb_cleanup_per_run)
         self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)
 

--- a/AndroidRunner/Progress.py
+++ b/AndroidRunner/Progress.py
@@ -67,13 +67,13 @@ class Progress(object):
                 if config['type'] == 'web':
                     for browser in config['browsers']:
                         subject_xml = self.build_subject_xml(device, path, browser)
-                        for run in range(config['replications']):
+                        for run in range(config['repetitions']):
                             runs_xml = runs_xml + '<run runId="{}">{}<runCount>{}</runCount></run>'. \
                                 format(run_id, subject_xml, run + 1)
                             run_id += 1
                 else:
                     subject_xml = self.build_subject_xml(device, path)
-                    for run in range(config['replications']):
+                    for run in range(config['repetitions']):
                         runs_xml = runs_xml + '<run runId="{}">{}<runCount>{}</runCount></run>'. \
                             format(run_id, subject_xml, run + 1)
                         run_id += 1

--- a/AndroidRunner/Tests.py
+++ b/AndroidRunner/Tests.py
@@ -24,3 +24,9 @@ def check_dependencies(devices, dependencies):
             for name in not_installed_apps:
                 logging.error('%s: Required package %s is not installed' % (device.id, name))
             raise ConfigError('Required packages %s are not installed on device %s' % (not_installed_apps, device.id))
+
+def is_valid_option(cmd, valid_options):
+    if cmd:
+        match = [x for x in valid_options if x == cmd]
+        if len(match) != 1:
+            raise ConfigError(""'"%s"'" not recognized.  Use one of: %s" % (cmd, valid_options))

--- a/AndroidRunner/Tests.py
+++ b/AndroidRunner/Tests.py
@@ -29,4 +29,5 @@ def is_valid_option(cmd, valid_options):
     if cmd:
         match = [x for x in valid_options if x == cmd]
         if len(match) != 1:
-            raise ConfigError(""'"%s"'" not recognized.  Use one of: %s" % (cmd, valid_options))
+            raise ConfigError("'%s' not recognized.  Use one of: %s" % (cmd, valid_options))
+    return cmd

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Additionally, the following are also required for the Batterystats method:
 
 Note: It is important that monkeyrunner shares the same adb the experiment is using. Otherwise, there will be an adb restart and output may be tainted by the notification.
 
-Note 2: You can specifiy the path to ADB and/or Monkeyrunner in the experiment configuration. See the Experiment Configuration section below.
+Note 2: You can specifiy the path to adb and/or Monkeyrunner in the experiment configuration. See the Experiment Configuration section below.
 
 Note 3: To check whether the the device is able to report on the `idle` and `frequency` states of the CPU, you can run the command `python systrace.py -l` and ensure both categories are listed among the supported categories.
 
@@ -34,13 +34,13 @@ Example configuration files can be found in the subdirectories of the `example` 
 
 ## Structure
 ### devices.json
-A JSON config that maps devices names to their ADB ids for easy reference in config files.
+A JSON config that maps devices names to their adb ids for easy reference in config files.
 
 ### Experiment Configuration
 Below is a reference to the fields for the experiment configuration. It is not always updated.
 
 **adb_path** *string*
-Path to ADB. Example path: `/opt/platform-tools/adb`
+Path to adb. Example path: `/opt/platform-tools/adb`
 
 **monkeyrunner_path** *string*
 Path to Monkeyrunner. Example path: `/opt/platform-tools/bin/monkeyrunner`
@@ -76,10 +76,13 @@ Number of times each experiment is run.
 Random order of run execution. Default is *false*.
 
 **duration** *positive integer*
-The duration of each run in milliseconds, default is 0. Setting a too short duration may lead to missing results when running native experiments, adviced is to set a higher duration time if unexpected results appear.
+The duration of each run in milliseconds, default is 0. Setting a too short duration may lead to missing results when running native experiments, it is advised to set a higher duration time if unexpected results appear.
+
+**adb_cleanup_per_run** *string*
+Provides flexibility for restarting adb connections after each run.  This field accepts *restart*.
 
 **time_between_run** *positive integer*
-The time that the framework waits between 2 succesive experiment runs. Default is 0.
+The time that the framework waits between 2 successive experiment runs. Default is 0.
 
 **devices** *JSON*
 A JSON object to describe the devices to be used and their arguments. Below are several examples:
@@ -108,10 +111,10 @@ A JSON object to describe the devices to be used and their arguments. Below are 
 ```
 Note that the last two examples result in the same behaviour.
 
-The root_disable_charging option specifies if the devices needs to be root charging disabled by writing the charging_disabled_value to the usb_charging_disabled_file. Different devices have different values for the charging_disabled_value and usb_charging_disabled_file, so be carefull when using this feature. Also keep an eye out on the battery percantage when ussing this feature. If the battery dies when the charging is root disabled, it becomes impossible to charge the device via USB. 
+The root_disable_charging option specifies if the devices needs to be root charging disabled by writing the charging_disabled_value to the usb_charging_disabled_file. Different devices have different values for the charging_disabled_value and usb_charging_disabled_file, so be careful when using this feature. Also keep an eye out on the battery percentage when using this feature. If the battery dies when the charging is root disabled, it becomes impossible to charge the device via USB.
 
 **WARNING:** Always check the battery settings of the device for the charging status of the device after using root disable charging.
-If the device isn't charging after the experiment is finished, reset the charging file yourself via ADB SU command line using:
+If the device isn't charging after the experiment is finished, reset the charging file yourself via adb su command line using:
 ```shell
 adb su -c 'echo <charging enabled value> > <usb_charging_disabled_file>'
 ```
@@ -173,7 +176,7 @@ A JSON object to describe the profilers to be used and their arguments. Below ar
     }
   }
 ```
-The garbage collection (GC) plugin gathers and counts GC log statements by searching in ADB's logcat for logs that meet the format of a GC call as described [here](https://dzone.com/articles/understanding-android-gc-logs).
+The garbage collection (GC) plugin gathers and counts GC log statements by searching in adb's logcat for logs that meet the format of a GC call as described [here](https://dzone.com/articles/understanding-android-gc-logs).
 The default subject aggregation lists the counted GC calls in a single file for easy further processing.
 ```json
   "profilers": {
@@ -183,11 +186,11 @@ The default subject aggregation lists the counted GC calls in a single file for 
     }
   }
 ```
-The frame times plugin gathers unique frame rendering durations (in nanoseconds) by utilizing `dumpsys gfxinfo framestats` and counts the amount of delayed frames that occurred following the 16ms threshold [defined by Google](https://developer.android.com/training/testing/performance). 
+The frame times plugin gathers unique frame rendering durations (in nanoseconds) by utilizing `dumpsys gfxinfo framestats` and counts the amount of delayed frames that occurred following the 16ms threshold [defined by Google](https://developer.android.com/training/testing/performance).
 The sample interval is configurable but advised to keep under 120 seconds as the framestats command returns only data from frames rendered in the past 120 seconds as described [here](https://developer.android.com/training/testing/performance).
 Shorter sample intervals will not cause duplication in the frames gathered as only unique frames are kept.
 The default subject aggregation consists of combining both the frametimes as the delayed frames count in single files for easy further processing.
- 
+
 **subject_aggregation** *string*
 Specify which subject aggregation to use. The default is the subject aggregation provided by the profiler. If a user specified aggregation script is used then the script should contain a ```bash main(dummy, data_dir)``` method, as this method is used as the entry point to the script.
 
@@ -229,7 +232,7 @@ Below are the supported types:
   executes after a run completes
 - after_experiment
   executes once after the last run
-  
+
 Instead of a path to string it is also possible to provide a JSON object in the following form:
 ```js
     "interaction": [
@@ -245,7 +248,7 @@ Within the JSON object you can use "type" to "python2", "monkeyrunner" or, "monk
 
 ## Plugin profilers
 It is possible to write your own profiler and use this with Android runner. To do so write your profiler in such a way
-that it uses [this profiler.py class](ExperimentRunner/Plugins/Profiler.py) as parent class. The device object that is mentioned within the profiler.py class is based on the device.py of this repo. To see what can be done with this object, see the source code [here](ExperimentRunner/Device.py).
+that it uses [this profiler.py class](AndroidRunner/Plugins/Profiler.py) as parent class. The device object that is mentioned within the profiler.py class is based on the device.py of this repo. To see what can be done with this object, see the source code [here](AndroidRunner/Device.py).
 
 You can use your own profiler in the same way as the default profilers, you just need to make sure that:
 - The profiler name is the same as your python file and class name.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Random order of run execution. Default is *false*.
 **duration** *positive integer*
 The duration of each run in milliseconds, default is 0. Setting a too short duration may lead to missing results when running native experiments, it is advised to set a higher duration time if unexpected results appear.
 
-**adb_cleanup_per_run** *string*
-Provides flexibility for restarting adb connections after each run.  This field accepts *restart*.  Recommended to run Android Runner as a privileged user to avoid potential issues with adb device authorizaton.
+**reset_adb_among_runs** *boolean*
+Restarts the adb connection after each run.  Default is *false*.  Recommended to run Android Runner as a privileged user to avoid potential issues with adb device authorizaton.
 
 **time_between_run** *positive integer*
 The time that the framework waits between 2 successive experiment runs. Default is 0.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Random order of run execution. Default is *false*.
 The duration of each run in milliseconds, default is 0. Setting a too short duration may lead to missing results when running native experiments, it is advised to set a higher duration time if unexpected results appear.
 
 **adb_cleanup_per_run** *string*
-Provides flexibility for restarting adb connections after each run.  This field accepts *restart*.
+Provides flexibility for restarting adb connections after each run.  This field accepts *restart*.  Recommended to run Android Runner as a privileged user to avoid potential issues with adb device authorizaton.
 
 **time_between_run** *positive integer*
 The time that the framework waits between 2 successive experiment runs. Default is 0.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Specify this property inside of your config to specify a `devices.json` outside 
  }
  ```
 
-**replications** *positive integer*
-Number of times an experiment is run.
+**repetitions** *positive integer*
+Number of times each experiment is run.
 
 **randomization** *boolean*
 Random order of run execution. Default is *false*.

--- a/examples/batterystats/config.json
+++ b/examples/batterystats/config.json
@@ -3,7 +3,7 @@
   "devices": {
     "j7duo2": {}
   },
-  "replications": 3,
+  "repetitions": 3,
   "duration": 60000,
   "monkeyrunner_path": "/home/user/Android/Sdk/tools/bin/monkeyrunner",
   "systrace_path": "/home/user/Android/Sdk/platform-tools/systrace/systrace.py",

--- a/examples/batterystats/config_web.json
+++ b/examples/batterystats/config_web.json
@@ -3,7 +3,7 @@
   "devices": {
     "nexus6p": {}
   },
-  "replications": 1,
+  "repetitions": 1,
   "duration": 60000,
   "browsers": ["chrome"],
   "monkeyrunner_path": "/home/user/Android/Sdk/tools/bin/monkeyrunner",

--- a/examples/native/config.json
+++ b/examples/native/config.json
@@ -4,7 +4,7 @@
     "j7duo2": {}
   },
   "duration": 5000,
-  "replications": 1,
+  "repetitions": 1,
   "duration": 5000,
   "apps": [
     "com.samsung.android.messaging"

--- a/examples/native/config_android.json
+++ b/examples/native/config_android.json
@@ -3,7 +3,7 @@
   "devices": {
     "nexus6p": {}
   },
-  "replications": 1,
+  "repetitions": 1,
   "apps": [
     "com.experimental.rvs960.ioapp"
   ],

--- a/examples/performance/config.json
+++ b/examples/performance/config.json
@@ -3,7 +3,7 @@
   "devices": {
     "nexus6p": {}
   },
-    "replications": 2,
+  "repetitions": 2,
   "apps": [
     "com.google.android.calendar",
     "com.android.chrome"

--- a/examples/plugin/config.json
+++ b/examples/plugin/config.json
@@ -3,7 +3,7 @@
   "devices": {
     "nexus6p": {}
   },
-  "replications": 1,
+  "repetitions": 1,
   "browsers": ["firefox"],
   "paths": [
     "https://google.com/",

--- a/examples/web/config.json
+++ b/examples/web/config.json
@@ -3,7 +3,7 @@
   "devices": {
     "j7duo2": {}
   },
-  "replications": 1,
+  "repetitions": 1,
   "randomization": "False",
   "browsers": ["firefox"],
   "paths": [

--- a/examples/web/config.json
+++ b/examples/web/config.json
@@ -4,7 +4,7 @@
     "j7duo2": {}
   },
   "repetitions": 1,
-  "randomization": "False",
+  "randomization": false,
   "browsers": ["firefox"],
   "paths": [
     "https://google.com/",

--- a/examples/web/config_root_charging_disabled.json
+++ b/examples/web/config_root_charging_disabled.json
@@ -8,7 +8,7 @@
     }
    },
   "repetitions": 1,
-  "randomization": "False",
+  "randomization": false,
   "browsers": ["firefox"],
   "paths": [
     "https://google.com/",

--- a/examples/web/config_root_charging_disabled.json
+++ b/examples/web/config_root_charging_disabled.json
@@ -7,7 +7,7 @@
         "usb_charging_disabled_file": "sys/class/power_supply/battery/charging_enabled"
     }
    },
-  "replications": 1,
+  "repetitions": 1,
   "randomization": "False",
   "browsers": ["firefox"],
   "paths": [

--- a/tests/unit/fixtures/test_config.json
+++ b/tests/unit/fixtures/test_config.json
@@ -2,7 +2,7 @@
   "type": "web",
   "devices": ["nexus6p"],
   "repetitions": 3,
-  "randomization": "False",
+  "randomization": false,
   "browsers": ["firefox"],
   "paths": [
     "https://google.com/",

--- a/tests/unit/fixtures/test_config.json
+++ b/tests/unit/fixtures/test_config.json
@@ -1,7 +1,7 @@
 {
   "type": "web",
   "devices": ["nexus6p"],
-  "replications": 3,
+  "repetitions": 3,
   "randomization": "False",
   "browsers": ["firefox"],
   "paths": [

--- a/tests/unit/fixtures/test_progress.xml
+++ b/tests/unit/fixtures/test_progress.xml
@@ -1,5 +1,5 @@
 <experiment>
-  <configHash>c563cc8583486714e40cf74b1fb98577</configHash>
+  <configHash>fd95f5b33d483e665d32510ae34051db</configHash>
   <outputDir>test/output/dir</outputDir>
   <runsToRun>
     <run runId="0">

--- a/tests/unit/fixtures/test_progress.xml
+++ b/tests/unit/fixtures/test_progress.xml
@@ -1,5 +1,5 @@
 <experiment>
-  <configHash>fd95f5b33d483e665d32510ae34051db</configHash>
+  <configHash>df40fc18fd82782d9c2712e5597c15d5</configHash>
   <outputDir>test/output/dir</outputDir>
   <runsToRun>
     <run runId="0">

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -902,9 +902,23 @@ class TestAdb(object):
                           call.get_logcat(lcfilter='-d -e {}'.format(test_regex))]
         assert mock_adb.mock_calls == expected_calls
 
-    def test_cleanup_restart(self):
+    def test_reset_true(self):
         Adb.adb = Mock()
-        cmd = 'restart'
-        Adb.cleanup(cmd)
+        cmd = 'True'
+        Adb.reset(cmd)
         expected_calls = [call.kill_server(), call.get_devices()]
         assert Adb.adb.mock_calls == expected_calls
+
+    def test_reset_true(self):
+        Adb.adb = Mock()
+        cmd = 'False'
+        Adb.reset(cmd)
+        expected_calls = []
+        assert Adb.adb.mock_calls == expected_calls
+
+    def test_reset_invalid(self):
+        Adb.adb = Mock()
+        cmd = 'terminate'
+        Adb.reset(cmd)
+        assert Adb.adb.kill_server.call_count == 0
+        assert Adb.adb.get_devices.call_count == 0

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -901,3 +901,10 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id),
                           call.get_logcat(lcfilter='-d -e {}'.format(test_regex))]
         assert mock_adb.mock_calls == expected_calls
+
+    def test_cleanup_restart(self):
+        Adb.adb = Mock()
+        cmd = 'restart'
+        Adb.cleanup(cmd)
+        expected_calls = [call.kill_server(), call.get_devices()]
+        assert Adb.adb.mock_calls == expected_calls

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -904,21 +904,14 @@ class TestAdb(object):
 
     def test_reset_true(self):
         Adb.adb = Mock()
-        cmd = 'True'
+        cmd = True
         Adb.reset(cmd)
         expected_calls = [call.kill_server(), call.get_devices()]
         assert Adb.adb.mock_calls == expected_calls
 
-    def test_reset_true(self):
+    def test_reset_false(self):
         Adb.adb = Mock()
-        cmd = 'False'
+        cmd = False
         Adb.reset(cmd)
         expected_calls = []
         assert Adb.adb.mock_calls == expected_calls
-
-    def test_reset_invalid(self):
-        Adb.adb = Mock()
-        cmd = 'terminate'
-        Adb.reset(cmd)
-        assert Adb.adb.kill_server.call_count == 0
-        assert Adb.adb.get_devices.call_count == 0

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -32,7 +32,7 @@ class TestExperiment(object):
         config['profilers'] = {'fake': {'config1': 1, 'config2': 2}}
         config['monkeyrunner_path'] = 'monkey_path'
         config['scripts'] = {'script1': 'path/to/1'}
-        config['reset_adb_among_runs'] = 'True'
+        config['reset_adb_among_runs'] = True
         config['time_between_run'] = 10
         return config
 
@@ -125,7 +125,7 @@ class TestExperiment(object):
         assert experiment.paths == ['test/paths/1', 'test/paths/2']
         assert 'Profilers()' in str(experiment.profilers)
         assert isinstance(experiment.scripts, Scripts)
-        assert experiment.reset_adb_among_runs == 'True'
+        assert experiment.reset_adb_among_runs is True
         assert experiment.time_between_run == 10
         assert experiment.output_root == paths.OUTPUT_DIR
         assert experiment.result_file_structure is None
@@ -508,7 +508,7 @@ class TestExperiment(object):
         mock_device = Mock()
         path = 'test/path'
         run = 1234566789
-        default_experiment.reset_adb_among_runs = 'True'
+        default_experiment.reset_adb_among_runs = True
         default_experiment.time_between_run = 2000
         mock_manager = Mock()
         mock_manager.attach_mock(script_run, "script_run_managed")
@@ -519,7 +519,7 @@ class TestExperiment(object):
 
         expected_calls = [call.script_run_managed('after_run', mock_device, *args, **kwargs),
                           call.collect_results_managed(mock_device),
-                          call.reset_managed('True'),
+                          call.reset_managed(True),
                           call.sleep_managed(2)
                          ]
         assert mock_manager.mock_calls == expected_calls

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -27,7 +27,7 @@ class TestExperiment(object):
         config['randomization'] = True
         config['adb_path'] = 'test_adb'
         config['devices'] = ['dev1', 'dev2']
-        config['replications'] = 10
+        config['repetitions'] = 10
         config['paths'] = ['test/paths/1', 'test/paths/2']
         config['profilers'] = {'fake': {'config1': 1, 'config2': 2}}
         config['monkeyrunner_path'] = 'monkey_path'
@@ -62,7 +62,7 @@ class TestExperiment(object):
         assert experiment.basedir is None
         assert experiment.random is False
         assert isinstance(experiment.devices, Devices)
-        assert experiment.replications == 1
+        assert experiment.repetitions == 1
         assert experiment.paths == []
         assert isinstance(experiment.profilers, Profilers)
         assert isinstance(experiment.scripts, Scripts)
@@ -86,7 +86,7 @@ class TestExperiment(object):
         assert experiment.basedir is None
         assert experiment.random is False
         assert isinstance(experiment.devices, Devices)
-        assert experiment.replications == 1
+        assert experiment.repetitions == 1
         assert experiment.paths == []
         assert isinstance(experiment.profilers, Profilers)
         assert isinstance(experiment.scripts, Scripts)
@@ -118,7 +118,7 @@ class TestExperiment(object):
         assert experiment.basedir is None
         assert experiment.random is True
         assert isinstance(experiment.devices, Devices)
-        assert experiment.replications == 10
+        assert experiment.repetitions == 10
         assert experiment.paths == ['test/paths/1', 'test/paths/2']
         assert 'Profilers()' in str(experiment.profilers)
         assert isinstance(experiment.scripts, Scripts)

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -32,7 +32,7 @@ class TestExperiment(object):
         config['profilers'] = {'fake': {'config1': 1, 'config2': 2}}
         config['monkeyrunner_path'] = 'monkey_path'
         config['scripts'] = {'script1': 'path/to/1'}
-        config['adb_cleanup_per_run'] = 'restart'
+        config['reset_adb_among_runs'] = 'True'
         config['time_between_run'] = 10
         return config
 
@@ -67,7 +67,7 @@ class TestExperiment(object):
         assert experiment.paths == []
         assert isinstance(experiment.profilers, Profilers)
         assert isinstance(experiment.scripts, Scripts)
-        assert experiment.adb_cleanup_per_run is False
+        assert experiment.reset_adb_among_runs is False
         assert experiment.time_between_run == 0
         assert experiment.output_root == paths.OUTPUT_DIR
         assert experiment.result_file_structure is None
@@ -92,7 +92,7 @@ class TestExperiment(object):
         assert experiment.paths == []
         assert isinstance(experiment.profilers, Profilers)
         assert isinstance(experiment.scripts, Scripts)
-        assert experiment.adb_cleanup_per_run is False
+        assert experiment.reset_adb_among_runs is False
         assert experiment.time_between_run == 0
         assert experiment.output_root == paths.OUTPUT_DIR
         assert experiment.result_file_structure is None
@@ -125,7 +125,7 @@ class TestExperiment(object):
         assert experiment.paths == ['test/paths/1', 'test/paths/2']
         assert 'Profilers()' in str(experiment.profilers)
         assert isinstance(experiment.scripts, Scripts)
-        assert experiment.adb_cleanup_per_run == 'restart'
+        assert experiment.reset_adb_among_runs == 'True'
         assert experiment.time_between_run == 10
         assert experiment.output_root == paths.OUTPUT_DIR
         assert experiment.result_file_structure is None
@@ -499,27 +499,27 @@ class TestExperiment(object):
         script_run.assert_called_once_with('before_close', mock_device, 123, current_activity)
 
     @patch('time.sleep')
-    @patch('AndroidRunner.Adb.cleanup')
+    @patch('AndroidRunner.Adb.reset')
     @patch('AndroidRunner.Profilers.Profilers.collect_results')
     @patch('AndroidRunner.Scripts.Scripts.run')
-    def test_after_run(self, script_run, collect_results, cleanup, sleep, default_experiment):
+    def test_after_run(self, script_run, collect_results, reset, sleep, default_experiment):
         args = (1, 2, 3)
         kwargs = {'arg1': 1, 'arg2': 2}
         mock_device = Mock()
         path = 'test/path'
         run = 1234566789
-        default_experiment.adb_cleanup_per_run = 'restart'
+        default_experiment.reset_adb_among_runs = 'True'
         default_experiment.time_between_run = 2000
         mock_manager = Mock()
         mock_manager.attach_mock(script_run, "script_run_managed")
         mock_manager.attach_mock(collect_results, "collect_results_managed")
-        mock_manager.attach_mock(cleanup, "cleanup_managed")
+        mock_manager.attach_mock(reset, "reset_managed")
         mock_manager.attach_mock(sleep, "sleep_managed")
         default_experiment.after_run(mock_device, path, run, *args, **kwargs)
 
         expected_calls = [call.script_run_managed('after_run', mock_device, *args, **kwargs),
                           call.collect_results_managed(mock_device),
-                          call.cleanup_managed('restart'),
+                          call.reset_managed('True'),
                           call.sleep_managed(2)
                          ]
         assert mock_manager.mock_calls == expected_calls

--- a/tests/unit/test_experiment.py
+++ b/tests/unit/test_experiment.py
@@ -499,10 +499,10 @@ class TestExperiment(object):
         script_run.assert_called_once_with('before_close', mock_device, 123, current_activity)
 
     @patch('time.sleep')
-    @patch('AndroidRunner.Adb.restart')
+    @patch('AndroidRunner.Adb.cleanup')
     @patch('AndroidRunner.Profilers.Profilers.collect_results')
     @patch('AndroidRunner.Scripts.Scripts.run')
-    def test_after_run(self, script_run, collect_results, restart, sleep, default_experiment):
+    def test_after_run(self, script_run, collect_results, cleanup, sleep, default_experiment):
         args = (1, 2, 3)
         kwargs = {'arg1': 1, 'arg2': 2}
         mock_device = Mock()
@@ -513,13 +513,13 @@ class TestExperiment(object):
         mock_manager = Mock()
         mock_manager.attach_mock(script_run, "script_run_managed")
         mock_manager.attach_mock(collect_results, "collect_results_managed")
-        mock_manager.attach_mock(restart, "restart_managed")
+        mock_manager.attach_mock(cleanup, "cleanup_managed")
         mock_manager.attach_mock(sleep, "sleep_managed")
         default_experiment.after_run(mock_device, path, run, *args, **kwargs)
 
         expected_calls = [call.script_run_managed('after_run', mock_device, *args, **kwargs),
                           call.collect_results_managed(mock_device),
-                          call.restart_managed(),
+                          call.cleanup_managed('restart'),
                           call.sleep_managed(2)
                          ]
         assert mock_manager.mock_calls == expected_calls

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -87,11 +87,11 @@ class TestProgressMethods(object):
 
     @pytest.fixture()
     def config_web_dict(self):
-        return {'devices': ['device1'], 'paths': ['path1'], 'type': 'web', 'browsers': ['browser1'], 'replications': 1}
+        return {'devices': ['device1'], 'paths': ['path1'], 'type': 'web', 'browsers': ['browser1'], 'repetitions': 1}
 
     @pytest.fixture()
     def config_native_dict(self):
-        return {'devices': ['device1'], 'paths': ['path1'], 'type': 'native', 'replications': 1}
+        return {'devices': ['device1'], 'paths': ['path1'], 'type': 'native', 'repetitions': 1}
 
     def elements_equal(self, e1, e2):
         if e1.tag != e2.tag:
@@ -154,7 +154,7 @@ class TestProgressMethods(object):
         assert expected_stripped == result_stripped
 
     def test_file_to_hash(self, current_progress, test_config):
-        expected_hash = "c563cc8583486714e40cf74b1fb98577"
+        expected_hash = "fd95f5b33d483e665d32510ae34051db"
         current_hash = current_progress.file_to_hash(test_config)
         assert current_hash == expected_hash
 

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -154,7 +154,7 @@ class TestProgressMethods(object):
         assert expected_stripped == result_stripped
 
     def test_file_to_hash(self, current_progress, test_config):
-        expected_hash = "fd95f5b33d483e665d32510ae34051db"
+        expected_hash = "df40fc18fd82782d9c2712e5597c15d5"
         current_hash = current_progress.file_to_hash(test_config)
         assert current_hash == expected_hash
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,7 +26,7 @@ class TestUtilClass(object):
         assert config['type'] == 'web'
         assert config['devices'] == ['nexus6p']
         assert config['randomization'] == 'False'
-        assert config['replications'] == 3
+        assert config['repetitions'] == 3
 
     def test_load_json_file_format_error(self, tmp_file):
         fixtures = op.join(op.dirname(op.realpath(__file__)), "fixtures")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -146,6 +146,20 @@ class TestTestsClass(object):
     def test_is_integer_succes(self):
         assert Tests.is_integer(10) == 10
 
+    def test_cmd_not_valid(self):
+        with pytest.raises(util.ConfigError) as except_result:
+            Tests.is_valid_option("r", ["restart", "abc"])
+        assert "'r' not recognized.  Use one of: ['restart', 'abc']" in str(except_result.value)
+
+    def test_more_than_one_cmd(self):
+        with pytest.raises(util.ConfigError) as except_result:
+            Tests.is_valid_option("restart abc", ["restart", "abc"])
+        assert "'restart abc' not recognized.  Use one of: ['restart', 'abc']" in str(except_result.value)
+
+    def test_cmd_is_valid(self):
+        test_command = "foo"
+        assert Tests.is_valid_option(test_command, ["bar","foo"]) == test_command
+
     def test_is_string_fail(self):
         with pytest.raises(util.ConfigError) as except_result:
             Tests.is_string(list())

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -25,7 +25,7 @@ class TestUtilClass(object):
         config = util.load_json(op.join(fixtures, 'test_config.json'))
         assert config['type'] == 'web'
         assert config['devices'] == ['nexus6p']
-        assert config['randomization'] == 'False'
+        assert config['randomization'] == False
         assert config['repetitions'] == 3
 
     def test_load_json_file_format_error(self, tmp_file):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -151,6 +151,11 @@ class TestTestsClass(object):
             Tests.is_valid_option("r", ["restart", "abc"])
         assert "'r' not recognized.  Use one of: ['restart', 'abc']" in str(except_result.value)
 
+    def test_cmd_truthy(self):
+        with pytest.raises(util.ConfigError) as except_result:
+            Tests.is_valid_option("True", [False, True])
+        assert "'True' not recognized.  Use one of: [False, True]" in str(except_result.value)
+
     def test_more_than_one_cmd(self):
         with pytest.raises(util.ConfigError) as except_result:
             Tests.is_valid_option("restart abc", ["restart", "abc"])


### PR DESCRIPTION
This PR adds the option to restart adb after each run.  Depending on the machine, using this option might require that the end user execute the experiment as a privileged user to prevent adb authorization problems.  I added a method in Tests.py that will confirm that the user inputted command in config.json matches the available options for that field located in Experiment.py.  Also included are updates to tests/unit/test_experiment.py, test_utils.py and test_devices.py.

Note 1: The calls to time.sleep in Adb.cleanup are necessary to avoid aggregation errors like IndexOutofRange.  I bumped up the seconds for insurance.

Note 2: The time to run test_devices.py increased by 15 seconds, since there are a total of 15 sleep seconds in adb_cleanup.

Other changes include spelling and grammatical corrections in README.