### PR TITLE
Simplify the overriding of Trepn preferences

### DIFF
--- a/AndroidRunner/Plugins/trepn/README.md
+++ b/AndroidRunner/Plugins/trepn/README.md
@@ -7,14 +7,27 @@ Below an example configuration is found:
 ```json
   "profilers": {
     "trepn": {
-      "sample_interval": 100,
+      "preferences": {
+        "profiling_interval": 100,
+        "battery_power_source_selection": "Direct Power"
+      },
       "data_points": ["battery_power", "mem_usage"]
     }
   }
 ```
 
-**sample_interval** *int*
-The sample interval in which the data points are gathered.
+**preferences** *Map<string, any>*
+The preferences and configurations set in the Trepn profiler.
+Defined in a map of `<preference_name, preference_value` pairs.
+The available preferences and their default values are listed in [preferences.xml](./preferences.xml).
+The `preference_name` refers to the preference substring after the last dot. 
+For instance, the Trepn preference `com.quicinc.preferences.general.profiling_interval` is mapped in the user JSON configuration file using `profiling_interval`.
+Currently, AR does not validate the override values, so make sure they are correct.
+
+| Preference name                  | Valid values                                                   | Description                                                   |
+|----------------------------------|----------------------------------------------------------------|---------------------------------------------------------------|
+| `battery_power_source_selection` | [`Auto-Select`, `Estimate Power Consumption`, `Direct Power` ] | Source used to measure the battery power                      |
+| `profiling_interval`             | positive integer higher than 0                                 | The rate in ms in which the selected data points are measured |
 
 **data_points** *Array<string>* 
 The types of data that should be measured defined in an array of string enums. Possible options are listed in [data_points.json](./data_points.json).

--- a/examples/native/config.json
+++ b/examples/native/config.json
@@ -3,18 +3,22 @@
   "devices": {
     "j7duo2": {}
   },
-  "duration": 5000,
   "repetitions": 1,
   "duration": 5000,
   "apps": [
     "com.samsung.android.messaging"
   ],
   "profilers": {
-     "trepn": {
-      "sample_interval": 200,
-      "data_points": ["battery_power"]
-     }
- },
+    "trepn": {
+      "preferences": {
+        "profiling_interval": 100,
+        "battery_power_source_selection": "Direct Power"
+      },
+      "data_points": [
+        "battery_power"
+      ]
+    }
+  },
   "scripts": {
     "before_experiment": "Scripts/before_experiment.py",
     "before_run": "Scripts/before_run.py",

--- a/examples/web/config.json
+++ b/examples/web/config.json
@@ -5,22 +5,34 @@
   },
   "repetitions": 1,
   "randomization": false,
-  "browsers": ["firefox"],
+  "browsers": [
+    "firefox"
+  ],
   "paths": [
     "https://google.com/",
     "https://apple.com/",
     "https://wikipedia.com/"
   ],
-  "profilers":{
- "trepn": {
-      "sample_interval": 200,
-      "data_points": ["battery_remaining", "mem_usage", "battery_power"]
-     },
+  "profilers": {
+    "trepn": {
+      "preferences": {
+        "profiling_interval": 100,
+        "battery_power_source_selection": "Direct Power"
+      },
+      "data_points": [
+        "battery_remaining",
+        "mem_usage",
+        "battery_power"
+      ]
+    },
     "android": {
       "subject_aggregation": "none",
-      "experiment_aggregation" : "Scripts/aggregate_android.py",
+      "experiment_aggregation": "Scripts/aggregate_android.py",
       "sample_interval": 200,
-      "data_points": ["cpu", "mem"]
+      "data_points": [
+        "cpu",
+        "mem"
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
This commit extends the overriding logic of Trepn preferences into a self-contained function, allowing users to override all configurations. Mirror the preferences key in the user-defined configuration to extend the overriding to any preference. To reduce the verbosity of the key, the mirrored key contains only the substring after the last dot. For instance, the preference `com.quicinc.preferences.general.profiling_interval` is mapped into `profiling_interval`.