### PR TITLE
Inform in the console UI when the waiting time between runs start

### DIFF
--- a/AndroidRunner/Experiment.py
+++ b/AndroidRunner/Experiment.py
@@ -215,7 +215,7 @@ class Experiment(object):
         self.scripts.run('after_run', device, *args, **kwargs)
         self.profilers.collect_results(device)
         Adb.reset(self.reset_adb_among_runs)
-        self.logger.debug('Sleeping for %s milliseconds' % self.time_between_run)
+        self.logger.info('Sleeping for %s milliseconds' % self.time_between_run)
         time.sleep(self.time_between_run / 1000.0)
 
     def after_last_run(self, device, path, *args, **kwargs):


### PR DESCRIPTION
The last task before waiting X seconds between runs is collecting results.
If something occurs in this task without triggering an exception (e.g., the computation froze), we won't know.
This can be particularly confusing for researches and students not familiar with AR.
Sure, we can check the log file and verify the sleeping statement there, but it would be nice to have this statement also printed in the console UI.