### PR TITLE
Clear up the Android profiler data points from the previous run

### DIFF
--- a/AndroidRunner/Plugins/android/Android.py
+++ b/AndroidRunner/Plugins/android/Android.py
@@ -62,6 +62,7 @@ class Android(Profiler):
 
     def start_profiling(self, device, **kwargs):
         self.profile = True
+        self.data = [['datetime'] + self.data_points]
         app = kwargs.get('app', None)
         self.get_data(device, app)
 


### PR DESCRIPTION
The Android profiler never clears up the collected data points.
Therefore, each run contains the data points collected in all runs prior to this run.
This commit ensures that the data points are reset before starting profiling.
Since the timer-based profiling can trigger one additional profiling after executing the `stop_profiling` method, it is safer to clear the data points array before starting the profiling.

### Output files of the Android profiler before this commit

Run number 1
```
datetime,cpu,mem
Fri Aug 28 14:14:28 GMT 2020,0.9,76682
Fri Aug 28 14:14:28 GMT 2020,0.9,76393
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:30 GMT 2020,0.9,76417
Fri Aug 28 14:14:30 GMT 2020,0.9,76425
Fri Aug 28 14:14:30 GMT 2020,0.9,76425
Fri Aug 28 14:14:31 GMT 2020,0.9,76392
Fri Aug 28 14:14:31 GMT 2020,0.9,76425
```

Run number 2
```
datetime,cpu,mem
Fri Aug 28 14:14:28 GMT 2020,0.9,76682
Fri Aug 28 14:14:28 GMT 2020,0.9,76393
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:29 GMT 2020,0.9,76417
Fri Aug 28 14:14:30 GMT 2020,0.9,76417
Fri Aug 28 14:14:30 GMT 2020,0.9,76425
Fri Aug 28 14:14:30 GMT 2020,0.9,76425
Fri Aug 28 14:14:31 GMT 2020,0.9,76392
Fri Aug 28 14:14:31 GMT 2020,0.9,76425
Fri Aug 28 14:14:52 GMT 2020,0.9,76738
Fri Aug 28 14:14:52 GMT 2020,0.9,76411
Fri Aug 28 14:14:53 GMT 2020,0.9,76439
Fri Aug 28 14:14:53 GMT 2020,0.9,76439
Fri Aug 28 14:14:53 GMT 2020,0.9,76439
Fri Aug 28 14:14:54 GMT 2020,0.9,76439
Fri Aug 28 14:14:54 GMT 2020,0.9,76439
Fri Aug 28 14:14:54 GMT 2020,0.9,76439
Fri Aug 28 14:14:55 GMT 2020,0.9,76405
Fri Aug 28 14:14:55 GMT 2020,0.9,76439
```