### PR TITLE
Fixes a typo when describing the `devices_spec` attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Path to Monkeyrunner. Example path: `/opt/platform-tools/bin/monkeyrunner`
 **type** *string*
 Type of the experiment. Can be `web`, `native` or `plugintest`
 
-**device_spec** *string*
+**devices_spec** *string*
 Specify this property inside of your config to specify a `devices.json` outside of the Android Runner repository. For example:
 
  ```js


### PR DESCRIPTION
When I was setting up my experiment I copied the attribute name fro the description.
Since there was a typo, the attribute was being ignored.
After double-checking in the README, I verified that there was a typo in the attribute description.