### PR TITLE
Fixes a failing test on the Trepn profiler preferences

### DIFF
--- a/tests/unit/fixtures/test_config.json
+++ b/tests/unit/fixtures/test_config.json
@@ -1,26 +1,38 @@
 {
   "type": "web",
-  "devices": ["nexus6p"],
+  "devices": [
+    "nexus6p"
+  ],
   "repetitions": 3,
   "randomization": false,
-  "browsers": ["firefox"],
+  "browsers": [
+    "firefox"
+  ],
   "paths": [
     "https://google.com/",
     "https://apple.com/",
     "https://wikipedia.com/"
   ],
-  "profilers":{
- "trepn": {
+  "profilers": {
+    "trepn": {
       "subject_aggregation": "none",
-      "experiment_aggregation" : "Scripts/aggregate_trepn.py",
-      "sample_interval": 100,
-      "data_points": ["battery_power", "mem_usage"]
-     },
+      "experiment_aggregation": "Scripts/aggregate_trepn.py",
+      "preferences": {
+        "profiling_interval": 100
+      },
+      "data_points": [
+        "battery_power",
+        "mem_usage"
+      ]
+    },
     "android": {
       "subject_aggregation": "none",
-      "experiment_aggregation" : "Scripts/aggregate_android.py",
+      "experiment_aggregation": "Scripts/aggregate_android.py",
       "sample_interval": 200,
-      "data_points": ["cpu", "mem"]
+      "data_points": [
+        "cpu",
+        "mem"
+      ]
     }
   },
   "scripts": {

--- a/tests/unit/fixtures/test_progress.xml
+++ b/tests/unit/fixtures/test_progress.xml
@@ -1,5 +1,5 @@
 <experiment>
-  <configHash>df40fc18fd82782d9c2712e5597c15d5</configHash>
+  <configHash>8bbc52b2deb22e83ac40b01abb04c95a</configHash>
   <outputDir>test/output/dir</outputDir>
   <runsToRun>
     <run runId="0">

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -841,7 +841,7 @@ class TestTrepnPlugin(object):
         assert trepn_plugin.dependencies() == ['com.quicinc.trepn']
 
     def test_build_preferences(self, trepn_plugin, tmpdir, fixture_dir):
-        test_params = {'sample_interval': 300, 'data_points': ['battery_power', 'mem_usage']}
+        test_params = {'preferences': {'profiling_interval': 300}, 'data_points': ['battery_power', 'mem_usage']}
         trepn_plugin.paths['OUTPUT_DIR'] = str(tmpdir)
 
         trepn_plugin.build_preferences(test_params)

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -154,7 +154,7 @@ class TestProgressMethods(object):
         assert expected_stripped == result_stripped
 
     def test_file_to_hash(self, current_progress, test_config):
-        expected_hash = "df40fc18fd82782d9c2712e5597c15d5"
+        expected_hash = "8bbc52b2deb22e83ac40b01abb04c95a"
         current_hash = current_progress.file_to_hash(test_config)
         assert current_hash == expected_hash
 


### PR DESCRIPTION
PR S2-group/android-runner#34 updates the Trepn profiler and allows overriding any preference. This caused a unit test to break as the PR updates the configuration file and replaces `sample_interval` attribute by a map of preferences. This should have been notified in the PR itself.