### PR TITLE
text mode for csv.DictReader

### DIFF
--- a/examples/trepn/Scripts/aggregate_trepn.py
+++ b/examples/trepn/Scripts/aggregate_trepn.py
@@ -20,7 +20,7 @@ def aggregate_trepn_final(logs_dir):
 
     runs = []
     for run_file in [f for f in os.listdir(logs_dir) if os.path.isfile(os.path.join(logs_dir, f))]:
-        with open(os.path.join(logs_dir, run_file), 'rb') as run:
+        with open(os.path.join(logs_dir, run_file), 'r') as run:
             run_dict = {}
             reader = csv.DictReader(run)
             column_readers = split_reader(reader)


### PR DESCRIPTION
While running on Python 3.8.2 coming with Ubunutu 20.04, I got the following error:

```
root: ScriptError: Error in aggregate_trepn.py: iterator should return strings, not bytes (did you open the file in text mode?)
Traceback (most recent call last):
  File "android-runner/AndroidRunner/Script.py", line 33, in mp_run
    output = self.execute_script(device, *args, **kwargs)
  File "android-runner/AndroidRunner/Python3.py", line 19, in execute_script
    return self.module.main(device, *args, **kwargs)
  File "/home/milica/android-runner/examples/trepn/Scripts/aggregate_trepn.py", line 79, in main
    rows = aggregate(data_dir)
  File "/home/milica/android-runner/examples/trepn/Scripts/aggregate_trepn.py", line 64, in aggregate
    row.update(aggregate_trepn_final(os.path.join(browser_dir, 'trepn')))
  File "/home/milica/android-runner/examples/trepn/Scripts/aggregate_trepn.py", line 26, in aggregate_trepn_final
    column_readers = split_reader(reader)
  File "/home/milica/android-runner/examples/trepn/Scripts/aggregate_trepn.py", line 40, in split_reader
    column_dicts = {fn: [] for fn in reader.fieldnames if not fn.split('[')[0].strip() == 'Time'}
  File "/usr/lib/python3.8/csv.py", line 97, in fieldnames
    self._fieldnames = next(self.reader)
_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)

root: An error occurred, the experiment has been stopped. To continue, add progress file argument to experiment startup: --progress /home/milica/android-runner/examples/trepn/output/2020.09.23_162040/progress.xml
```

Changing the mode from binary to text (default) solved the problem for me.
