### PR TITLE
add xapk (multiple apk files) install feature

### DIFF
--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -743,7 +743,7 @@ class TestAdb(object):
         mock_adb._ADB__output = 'succes'
         Adb.adb = mock_adb
         device_id = 123
-        apk = 'test_apk.xapk'
+        apk = 'test/test_apk.xapk'
 
         getcwd.return_value = 'test'
         result = Adb.install(device_id, apk)

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -737,6 +737,19 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
+    def test_install_multiple_default(self):
+        mock_adb = Mock()
+        mock_adb._ADB__output = 'succes'
+        Adb.adb = mock_adb
+        device_id = 123
+        apk = 'test_apk.xapk'
+
+        result = Adb.install(device_id, apk)
+
+        assert result == 'succes'
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install-multiple -r -g {}'.format(apk))]
+        assert mock_adb.mock_calls == expected_calls
+
     def test_install_no_replace(self):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -737,9 +737,9 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
-    @patch('test_devices.os.getcwd')
-    @patch('test_devices.os.chdir')
-    @patch('test_devices.os.makedirs')
+    @patch('os.getcwd')
+    @patch('os.chdir')
+    @patch('os.makedirs')
     def test_install_multiple_default(self):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -738,15 +738,14 @@ class TestAdb(object):
         assert mock_adb.mock_calls == expected_calls
 
     @patch('os.getcwd')
-    @patch('os.chdir')
-    @patch('os.makedirs')
-    def test_install_multiple_default(self):
+    def test_install_multiple_default(self, getcwd):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'
         Adb.adb = mock_adb
         device_id = 123
         apk = 'test_apk.xapk'
 
+        getcwd.return_value = 'test'
         result = Adb.install(device_id, apk)
 
         assert result == 'succes'

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -737,15 +737,19 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
-    @patch('os.getcwd')
-    def test_install_multiple_default(self, getcwd):
+    
+    @patch('Adb.os.listdir')
+    @patch('Adb.os.getcwd')
+    def test_install_multiple_default(self, listdir, getcwd):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'
         Adb.adb = mock_adb
         device_id = 123
-        apk = 'test/test_apk.xapk'
+        apk = 'test_apk.xapk'
 
-        getcwd.return_value = 'test'
+        getcwd.return_value = '.'
+        listdir.return_value = [apk]
+        
         result = Adb.install(device_id, apk)
 
         assert result == 'succes'

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -737,6 +737,9 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
+    @patch('test_devices.os.getcwd')
+    @patch('test_devices.os.chdir')
+    @patch('test_devices.os.makedirs')
     def test_install_multiple_default(self):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -738,8 +738,8 @@ class TestAdb(object):
         assert mock_adb.mock_calls == expected_calls
 
     
-    @patch('Adb.os.listdir')
-    @patch('Adb.os.getcwd')
+    @patch('os.listdir')
+    @patch('os.getcwd')
     def test_install_multiple_default(self, listdir, getcwd):
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'


### PR DESCRIPTION
Add support for installing native apps that have .xapk extension.

Currently only support for .xapk's that only have multiple .apk files in it.

No support yet for the other variant with .xapk's that have a .obb file in it.

Supply path of xapk to paths in the JSON config.

Example config: 
`"paths": [
    "android-runner/experiments/apps/com.alibaba.aliexpresshd.xapk",
    "android-runner/experiments/apps/com.deliveroo.orderapp.xapk",
    "android-runner/experiments/apps/com.reddit.frontpage.xapk",
    "android-runner/experiments/apps/com.google.android.youtube.xapk",
    "android-runner/experiments/apps/com.ninegag.android.app.apk",
    "android-runner/experiments/apps/com.weather.Weather.apk",
    "android-runner/experiments/apps/com.inditex.zara.apk"
  ],`