### PR TITLE
Added Ubuntu 20.04 Install instructions (monkeyrunner fix)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 Thank you for your interest in using the Android Runner framework.  Android Runner has been built up in iterative steps by bachelor's, master's, PhD students and professors.  Our goal is to make performance and energy consumption research on Android devices more accessible and robust.  The framework provides many tools and plugins to make this possible.
 
 ## Requirements
-This framework requires Python 3 along with MacOS or Linux.  Current and former contributors have used Ubuntu 18.04 along with Python 3.6.9.  
+This framework requires Python 3 along with MacOS or Linux.  Current and former contributors have used Ubuntu 18.04 and Ubuntu 20.04 along with Python 3.6.9 and 3.7.4.
 
 ## Setting up environment and dependencies
 1. Click on the **Fork** icon in the top right hand corner once you're logged into Github.
@@ -12,24 +12,41 @@ This framework requires Python 3 along with MacOS or Linux.  Current and former 
 3. Type `cd android-runner` to enter the framework's main directory.  Now, add a remote tracker to the parent repository with `git remote add upstream https://github.com/S2-group/android-runner`.  This is useful in case any major changes occur to the parent directory that may affect your project.  `git remote -vv` should now show *origin* and *upstream*.
 4. Create a virtual environment: `python3 -m venv /path/`.  This can be anywhere on your machine.  Activate it with `source /path/bin/activate`.
 5. Install dependencies.
-    - On Linux
-        - Android Debug Bridge (`sudo apt install android-tools-adb`)
-        - Android SDK Tools (`sudo apt install monkeyrunner`)
-        - JDK 8 (NOT JDK 9) (`sudo apt install openjdk-8-jre`)
-            - See [this](https://askubuntu.com/questions/740757/switch-between-multiple-java-versions) for switching between java versions
-        - lxml (`sudo apt install python-lxml`)
-    - On Mac OS
-        - Make sure you have <a href="https://brew.sh/">Homebrew</a> installed
-        - `brew cask install homebrew/cask-versions/adoptopenjdk8 android-sdk android-platform-tools`
-        - `brew install libxml2`
-        - Run `java -version`, if you are running a different version than 1.8/8:
-            - `brew install jenv`
-            - Run `/usr/libexec/java_home -V` to see the location of your Java environments
-            - Copy the location of your AdoptOpenJDK8 environment
-            - Run `jenv add <AdoptOpenJDK8_path>`
-            - Run `jenv global 1.8`
-            - Restart terminal and verify your Java version with `java -version`, it should output `openjdk version "1.8.0_265"`
-        - Verify that monkeyrunner works with `monkeyrunner --version`, it should output unrecognized argument and no other errors
+   1. Select your platform below:
+        - On Linux (Ubuntu 18.04)
+            - Android Debug Bridge (`sudo apt install android-tools-adb`)
+            - Android SDK Tools (`sudo apt install monkeyrunner`)
+            - JDK 8 (NOT JDK 9) (`sudo apt install openjdk-8-jre`)
+                - See [this](https://askubuntu.com/questions/740757/switch-between-multiple-java-versions) for switching between java versions
+            - lxml (`sudo apt install python-lxml`)
+        - On Linux (Ubuntu 20.04 and other versions/distros where monkeyrunner is not available from the package archive.)
+            - Download Android Studio from [here](https://developer.android.com/studio#downloads).
+            - Extract the archive, `cd` into its directory and install Android Studio by running `./bin/studio.sh`
+            - During the setup wizard Android Studio will ask you where you want to install the Android SDK. By default it is in `/home/user/Android/Sdk`
+            - The Android SDK, including ADB and Monkey Runner, is now installed on your system. To access the Android tools directly via your shell (preferable) add the following to your .bashrc/.zshrc:
+              
+              ```
+              export ANDROID_HOME=$HOME/Android/Sdk
+              export PATH=$PATH:$ANDROID_HOME/tools/bin
+              export PATH=$PATH:$ANDROID_HOME/platform-tools
+              ```
+            - Reload your .bashrc/.zshrc settings by running `source ~/.bashrc` or `source ~/.zshrc`
+            - Since MonkeyRunner requires JDK8 (not JDK9) we need to install JDK 8: `sudo apt install openjdk-8-jre`.
+                - Once JDK8 is installed we need to actually set it as default. See [here](https://askubuntu.com/questions/740757/switch-between-multiple-java-versions) how to do that.
+            - To verify if everything works correctly run `adb --version`. This should return its version number and install location. To do the same for Monkey Runner run `monkeyrunner --version`. This should return a `Unrecognized argument: --version.` but no other errors.
+            - Install lxml using `sudo apt install python-lxml`.
+        - On Mac OS
+             - Make sure you have <a href="https://brew.sh/">Homebrew</a> installed
+             - `brew cask install homebrew/cask-versions/adoptopenjdk8 android-sdk android-platform-tools`
+             - `brew install libxml2`
+             - Run `java -version`, if you are running a different version than 1.8/8:
+                - `brew install jenv`
+                - Run `/usr/libexec/java_home -V` to see the location of your Java environments
+                - Copy the location of your AdoptOpenJDK8 environment
+                - Run `jenv add <AdoptOpenJDK8_path>`
+                - Run `jenv global 1.8`
+                - Restart terminal and verify your Java version with `java -version`, it should output `openjdk version "1.8.0_265"`
+             - Verify that monkeyrunner works with `monkeyrunner --version`, it should output unrecognized argument and no other errors
     1. Within Android Runner's main directory
         - `pip install -r requirements.txt`  
     2. For creating or editing unit tests to ensure pull request passes TravisCI


### PR DESCRIPTION
As of Ubuntu 20.04 the `monkeyrunner` package is not available as a package in the Ubuntu package repository, see here: https://packages.ubuntu.com/search?keywords=monkeyrunner&searchon=names&suite=focal&section=all

There is a package in Ubuntu 20.04 called `android-sdk`. However, this package does also NOT include the monkeyrunner tool.

The easiest way to get monkeyrunner (and ADB as well) on Ubuntu 20.04 is to install Android Studio and change your .bashrc/.zshrc file accordingly so you can access these tools directly from your shell.
