### PR TITLE
Fixed tests for #58: install multiple apks using xapk

### DIFF
--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -737,24 +737,36 @@ class TestAdb(object):
         expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
-    
-    @patch('os.listdir')
-    @patch('os.getcwd')
-    def test_install_multiple_default(self, listdir, getcwd):
+    @patch("zipfile.ZipFile")
+    def test_install_multiple_default(self, zipfile, tmpdir):
+        xapk_file = tmpdir.mkdir("xapk").join("test_apk.xapk")
+        apk_file = tmpdir.mkdir("xapk/test_apk/").join("test_apk.apk")
+
+        xapk_file.write("This is an xapk file")
+        apk_file.write("This is an apk file")
+        device_id = 123
+
         mock_adb = Mock()
         mock_adb._ADB__output = 'succes'
         Adb.adb = mock_adb
-        device_id = 123
-        apk = 'test_apk.xapk'
-
-        getcwd.return_value = '.'
-        listdir.return_value = [apk]
-        
-        result = Adb.install(device_id, apk)
+        result = Adb.install(device_id, xapk_file)
 
         assert result == 'succes'
-        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install-multiple -r -g {}'.format(apk))]
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install-multiple -r -g {}'.format(apk_file))]
         assert mock_adb.mock_calls == expected_calls
+
+    @patch("zipfile.ZipFile")
+    def test_install_multiple_no_apks_in_xapk_file(self, zipfile, tmpdir):
+        xapk_file = tmpdir.mkdir("xapk").join("test_apk.xapk")
+        xapk_file.write("This is an xapk file")
+        device_id = 123
+
+        mock_adb = Mock()
+        mock_adb._ADB__output = 'succes'
+        Adb.adb = mock_adb
+
+        with pytest.raises(ConfigError):
+            Adb.install(device_id, xapk_file)
 
     def test_install_no_replace(self):
         mock_adb = Mock()


### PR DESCRIPTION
The merge of pull request #58 introduced a failing test. Test was fixed using tmpdir to mock the filesystem as recommended here https://github.com/S2-group/android-runner/pull/58#issuecomment-724963457.

Also another test was added to check if the function works as expected when an empty xapk is provided.