### PR TITLE
Fix failing tests for current_activity function.

### DIFF
--- a/AndroidRunner/Device.py
+++ b/AndroidRunner/Device.py
@@ -128,7 +128,7 @@ class Device:
             self.logger.debug('Current activity: %s' % result)
             return result
         else:
-            self.logger.error('Results from dumpsys window windows: \n%s' % windows)
+            self.logger.error(f'Results from dumpsys: {recent_activity}')
             raise AdbError('Could not parse activity from dumpsys')
 
     def launch_package(self, package):

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -337,6 +337,11 @@ class TestDevice(object):
         adb_shell_su.assert_called_once_with(123456789, 'echo 123456 > test/file')
 
     @patch('AndroidRunner.Adb.shell')
+    def test_current_activity_success(self, adb_shell, device):
+        adb_shell.return_value = "com.android.chrome"
+        assert device.current_activity() == "com.android.chrome"
+
+    @patch('AndroidRunner.Adb.shell')
     def test_current_activity_error(self, adb_shell, device):
         adb_shell.return_value = None
         with pytest.raises(Adb.AdbError):

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -337,29 +337,8 @@ class TestDevice(object):
         adb_shell_su.assert_called_once_with(123456789, 'echo 123456 > test/file')
 
     @patch('AndroidRunner.Adb.shell')
-    def test_current_activity_current_focus(self, adb_shell, device):
-        adb_shell.return_value = 'mCurrentFocus=Window{28d47066 u0 com.android.chrome/org.chromium.chrome.browser.' \
-                                 'ChromeTabbedActivity}\nmFocusedApp=Window{3078b3ad u0 com.sonyericsson.usbux/com.' \
-                                 'sonyericsson.usbux.settings.ConnectivitySettingsActivity}'
-        current_activity = device.current_activity()
-        assert current_activity == 'com.android.chrome'
-
-    @patch('AndroidRunner.Adb.shell')
-    def test_current_activity_focused_app(self, adb_shell, device):
-        adb_shell.return_value = 'mFocusedApp=AppWindowToken{ce6dd8c token=Token{31892bf ActivityRecord{21e5e0de u0 ' \
-                                 'com.android.chrome/org.chromium.chrome.browser.ChromeTabbedActivity t25385}}}'
-        current_activity = device.current_activity()
-        assert current_activity == 'com.android.chrome'
-
-    @patch('AndroidRunner.Adb.shell')
-    def test_current_activity_none(self, adb_shell, device):
-        adb_shell.return_value = 'mFocusedApp=null'
-        current_activity = device.current_activity()
-        assert current_activity is None
-
-    @patch('AndroidRunner.Adb.shell')
     def test_current_activity_error(self, adb_shell, device):
-        adb_shell.return_value = 'mFocusedApp=ajislvfhbljhglalkjasfdhdhg'
+        adb_shell.return_value = None
         with pytest.raises(Adb.AdbError):
             device.current_activity()
 


### PR DESCRIPTION
Pull request #57 broke tests as it introduces a new way to get the current activity. Instead of extracting the activity data in Python using regular expressions it delegates it to the command line utilities `grep` and `cut`:

Old way:
https://github.com/S2-group/android-runner/blob/a0c1ed1faa0b1e28fc52cc89c8853e60bbf518b9/AndroidRunner/Device.py#L122-L150

New way: 
https://github.com/S2-group/android-runner/blob/e7f402b2ca6819cfd167691c780b80adf8c93044/AndroidRunner/Device.py#L122-L132

Since the data extraction is now delegated to grep and cut it is difficult to employ the same tests. For now I've just deleted most of them.