### PR TITLE
Added compatible devices table

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,15 @@ In case of an error or a user abort during experiment execution, it is possible 
 
 ```python3 android_runner your_config.json --progress path/to/progress.xml```
 
+## Compatible Devices
+The table below shows on which mobile devices Android Runner was tested and whether there are any known issues.
+
+| Device                 | Compatibility                                                                                                                                                                       |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------                                 |
+| Google Nexus 5X        | No issues                                                                                                                                                                                    |
+| LG G6                  | No issues                                                                                                                                                                           |
+| Motorola Moto G5S Plus | BatteryStats is not available as APKTool can't disassemble the retrieved APK. See more [here](https://github.com/iBotPeaches/Apktool/issues/1420/). Trepn works without any issues. |
+
 ## Detailed documentation
 The original thesis can be found here:
 https://drive.google.com/file/d/0B7Fel9yGl5-xc2lEWmNVYkU5d2c/view?usp=sharing


### PR DESCRIPTION
Added table to README.md which gives an overview of tested devices and whether there are any known issues. 

For example, the BatteryStats plugin requires the disassembly of the retrieved framework-res.apk using APKTool. However, this can be a problem with devices from specific OEMs as they introduce their own qualifiers and thus breaking the AOSP which APKTools follows. The APKTool creators are thinking of creating a plugin system to handle these custom qualifiers but there is no ETA yet. See here for more: https://github.com/iBotPeaches/Apktool/issues/1420/. So on some devices using the BatteryStats plugin will be difficult.

