### PR TITLE
Fixes #41 file not found error when using Trepn.

### DIFF
--- a/AndroidRunner/util.py
+++ b/AndroidRunner/util.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import time
 import os
 import re
 from collections import OrderedDict
@@ -54,6 +55,37 @@ def makedirs(path):
         if e.errno != errno.EEXIST:
             raise
 
+def wait_until(function, timeout, period=0.25, *args):
+    """ Block/suspend/sleep for a maximum of <timeout> seconds until function <function> returns True. Execute <function> every
+    <period> seconds. If <function> still returns False after <timeout> seconds throw a TimeourError.
+
+    Parameters
+    ----------
+    function : callable
+        A Python function or method
+    timeout : float
+        Time in seconds until TimeoutError is thrown.
+    period : float
+        Time in seconds between each <function> call.
+    args : any
+        Arguments that are passed to <function>.
+
+    Raises
+    -------
+    TimeoutError
+        If <function> still returns False after <timeout> seconds.
+
+    Returns
+    -------
+    None
+        Nothing is returned.
+    """
+    must_end = time.time() + timeout
+    while time.time() < must_end:
+        if function(*args):
+            return
+        time.sleep(period)
+    raise TimeoutError
 
 # noinspection PyTypeChecker
 def slugify_dir(value):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -47,6 +47,23 @@ class TestUtilClass(object):
             util.load_json(tmp_file)
         assert "Permission denied" in str(except_result.value)
 
+    @patch("time.sleep")
+    def test_wait_until_call_succeeded(self, time_sleep_mock):
+        func_ = Mock()
+        func_.side_effect = [False, False, True]
+
+        util.wait_until(func_, 5)
+
+        assert func_.call_count == 3
+
+    @patch("time.sleep")
+    def test_wait_until_call_timeout_error(self, time_sleep_mock):
+        func_ = Mock()
+        func_.return_value = False
+
+        with pytest.raises(TimeoutError):
+            util.wait_until(func_, 5)
+
     def test_makedirs_succes(self, tmpdir):
         dir_path = op.join(str(tmpdir), 'test1')
         assert op.isdir(dir_path) is False


### PR DESCRIPTION
The problem described in #41 was caused by the fact that converting the Trepn database to a csv file and moving that csv file to the host takes time. However, the functions doing these actions are non-blocking and thus the flow of the program just continues even if the conversion and moving is not finished.

To fix this issue we now wait till the required files are successfully created and moved before the program flow continues.