### PR TITLE
Fixed logcat -e regex issue #39 by using grep. 

### DIFF
--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -171,16 +171,33 @@ def pull(device_id, remote, local):
         adb._ADB__error = None
     return adb._ADB__output
 
-
 def logcat(device_id, regex=None):
-    # https://developer.android.com/studio/command-line/logcat.html#Syntax
-    # -d prints to screen and exits
-    params = '-d'
-    if regex is not None:
-        params += ' -e %s' % regex
-    adb.set_target_by_name(device_id)
-    return adb.get_logcat(lcfilter=params)
+    """Returns the logcat log for the given device.
 
+    When regex is provided, only return log entries that match the regex.
+
+    Grep is used to handle regular expressions. While the logcat command itself supports regular expressions using
+    the -e flag it is not available on all devices.
+    Using grep circumvents this problem provided that the host OS has grep installed.
+
+    Parameters
+    ----------
+    device_id : string
+        ID of the device we want to see the logcat log of.
+    regex : string, optional, default=None
+        The regular expression
+
+    Returns
+    -------
+    string
+        The full logcat log or the logcat entries that match the regular expression.
+    """
+    # -d prints to screen and exits
+    params = 'logcat -d'
+    if regex is not None:
+        params += f' | grep "{regex}"'
+    res = shell(device_id, params)
+    return res
 
 def reset(cmd):
     if cmd:

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -932,22 +932,21 @@ class TestAdb(object):
 
     def test_logcat_no_regex(self):
         mock_adb = Mock()
-        mock_adb.get_logcat.return_value = 'get_logcat output'
-        Adb.adb = mock_adb
+        mock_adb.return_value = 'get_logcat output'
+        Adb.shell = mock_adb
 
         device_id = 123
 
         result = Adb.logcat(device_id)
 
         assert result == 'get_logcat output'
-        expected_calls = [call.set_target_by_name(device_id),
-                          call.get_logcat(lcfilter='-d')]
+        expected_calls = [call.shell(device_id, f"logcat -d")]
         assert mock_adb.mock_calls == expected_calls
 
     def test_logcat_with_regex(self):
         mock_adb = Mock()
-        mock_adb.get_logcat.return_value = 'get_logcat output'
-        Adb.adb = mock_adb
+        mock_adb.return_value = 'get_logcat output'
+        Adb.shell = mock_adb
 
         test_regex = '[a-zA-Z]+'
         device_id = 123
@@ -955,8 +954,7 @@ class TestAdb(object):
         result = Adb.logcat(device_id, test_regex)
 
         assert result == 'get_logcat output'
-        expected_calls = [call.set_target_by_name(device_id),
-                          call.get_logcat(lcfilter='-d -e {}'.format(test_regex))]
+        expected_calls = [call.shell(device_id, f'logcat -d | grep "{test_regex}"')]
         assert mock_adb.mock_calls == expected_calls
 
     def test_reset_true(self):


### PR DESCRIPTION
Fixes issue #39 by using grep for regular expression instead of the logcat command with the -e flag. The -e flag is not supported on all mobile devices. Using grep solves this problem provided that the host has grep installed. Fortunately, grep is available on nearly all *nix systems and if not, can be easily installed. 