### PR TITLE
Fixes issue #37 of AR execution being stuck/frozen for long periods of time

### DIFF
--- a/AndroidRunner/Plugins/monsoon/Monsoon.py
+++ b/AndroidRunner/Plugins/monsoon/Monsoon.py
@@ -24,6 +24,9 @@ class Monsoon(Profiler):
 
     def start_profiling(self, device, **kwargs):
         """Start the profiling process"""
+
+        # Quickly let the mobile device sleep and wake up so a run can take up to 30 minutes.
+        device.shell("input keyevent KEYCODE_SLEEP")
         device.shell("input keyevent KEYCODE_WAKEUP")
         time.sleep(5)
         self.profile = True
@@ -32,8 +35,13 @@ class Monsoon(Profiler):
     def stop_profiling(self, device, **kwargs):
         """Stop the profiling process"""
         self.results = power_meter.stop()
-        device.shell("input keyevent KEYCODE_SLEEP")
         self.profile = False
+
+        # Quickly let the mobile device sleep and wake up so the device is awake for 30 minutes.
+        # This solves the issue of certain commands sent to the device blocking the execution of the program.
+        device.shell("input keyevent KEYCODE_SLEEP")
+        device.shell("input keyevent KEYCODE_WAKEUP")
+        time.sleep(5)
 
     def collect_results(self, device):
         """Collect the data and clean up extra files on the device, save data in location set by 'set_output' """

--- a/AndroidRunner/Plugins/monsoon/README.md
+++ b/AndroidRunner/Plugins/monsoon/README.md
@@ -65,11 +65,12 @@ Follow these instructions to power on the phone:
 
 ## Things to know before running first real experiment
 1. The field `reset_adb_among_runs` should either be set to *false* or not be included in the configuration file.
-2. The `duration` of each run must not exceed 30 minutes, or 1,800,000 milliseconds if the phone screen needs to be on during the experiment.  Note, `time_between_run` is not affected by this requirement.
-3. Don't forget to add the phone's IP address and port to `devices.json`.
-4. For best stability, make sure the device is as close to the router as possible.  The device may disconnect from the adb server if the WiFi connection isn't stable.
-5. It's not required to turn off Monsoon before changing the `vout` field.  Monsoon can adjust that while it's powered on.
-6. The script will create a csv file in the same directory that will get overwritten every time an experiment is run.  
+2. The `duration` of each run must not exceed 30 minutes, or 1,800,000 milliseconds if the phone screen needs to be on during the experiment.  
+3. It is advisable to keep the time period between the "profiler stop" event and "profiler start" event (so including the before_close, after_run, before_run and after_launch phases) not to exceed 30 minutes. Note, `time_between_run` **is** affected by this requirement. If this requirement is not satisfied some commands send to the device may freeze the execution of AR.
+4. Don't forget to add the phone's IP address and port to `devices.json`.
+5. For best stability, make sure the device is as close to the router as possible.  The device may disconnect from the adb server if the WiFi connection isn't stable.
+6. It's not required to turn off Monsoon before changing the `vout` field.  Monsoon can adjust that while it's powered on.
+7. The script will create a csv file in the same directory that will get overwritten every time an experiment is run.  
 
 ## Running the experiment
 It's time to run a real experiment.


### PR DESCRIPTION
In some cases execution of AR freezes/blocks for a very long time when sending a command to the device through ADB. This can take up to 8 minutes and there are multiple of these commands in a single run. This makes running experiments slow.

This is caused because the device is in sleep mode (screen turned off) AND uses ADB through WiFi AND is not connected through USB with ADB (only through WiFi). Some commands (not all, adblogcat for example works instantly) that are required for the experiment block for a very long time. This is not a problem when the screen is on (device is awake).

To fix this issue we simply make sure the device is awake during the full experiment by sending am `input keyevent KEYCODE_WAKEUP` to the device right before profiling and right after profiling. 