### PR TITLE
Implemented the run_stopping_condition functionality.

### DIFF
--- a/AndroidRunner/NativeExperiment.py
+++ b/AndroidRunner/NativeExperiment.py
@@ -45,6 +45,9 @@ class NativeExperiment(Experiment):
 
     def start_profiling(self, device, path, run, *args, **kwargs):
         self.profilers.start_profiling(device, app=self.package)
+
+    def interaction(self, device, path, run, *args, **kwargs):
+        super(NativeExperiment, self).interaction(device, path, run, *args, **kwargs)
         time.sleep(self.duration)
 
     def after_run(self, device, path, run, *args, **kwargs):

--- a/AndroidRunner/PrematureStoppableRun.py
+++ b/AndroidRunner/PrematureStoppableRun.py
@@ -1,0 +1,182 @@
+import logging
+from .StopRunWebserver import StopRunWebserver
+from .util import ConfigError, keyboardinterrupt_handler
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import multiprocessing as mp
+import psutil
+
+class PrematureStoppableRun(object):
+    """ Starts a run that is stopped prematurely when:
+        1. a certain regex is matched in the logcat of the given device.
+        2. a HTTP POST request is received by the local webserver.  
+        3. the stop() method is called on the Experiment object instance.
+
+        If this does not happen the run continues and finishes as usual thus not stopping early/prematurely.
+
+        When an user chooses either the logcat_regex or post_request method he/she can also use the stop() function call.
+
+        A "run" in Android Runner basically consists of what happens between the start_profiling and stop_profiling functional calls.
+        In AR this is the interaction function. So we want to run this function and stop it when a regex is matched, 
+        post request is received or function call is executed.
+        
+        From a high level perspective it works as follows:
+        We run two processes (in addition to our main process) simultaneously:
+        1. A process running the interaction function (the AR "run")
+        2. A processes that either:
+            - runs a webserver (for the post_request option) or
+            - continuosly checks the logcat for the given regex (for the logcat_regex option). 
+        In addition we have a queue which is shared among these two processes (as well as the main process).
+        We then block the main process, waiting for one of the two processes to write to the queue.
+        The process running the interaction function will write to the queue when the interation (and thus the run) has finished.
+        The process running either a webserver will write to the queue when a HTTP POST request is received or when the logcat matches the regex.
+        When the stop() method is called on the Experiment object instance it will also write to the queue.
+        After a process writes to the queue the given process is finished and the main process will continue as well.
+        We then terminate the "other" process that is left. 
+        For example: when HTTP POST request was received or logcat regex was matched the interaction process will get terminated thus stopping the run and vice versa.
+    """
+
+    STOPPING_MECHANISM_HTTP_POST_REQUEST = "HTTP POST request"
+    STOPPING_MECHANISM_LOGCAT_REGEX = "matching regex"
+    STOPPING_MECHANISM_FUNCTION_CALL = "stop() function call"
+
+    def __init__(self, run_stopping_condition_config, queue, interaction_function, device, path, run, *args, **kwargs):
+        """ Creates a PrematureStoppableRun instance. 
+
+            Parameters
+            ----------
+            run_stopping_condition_config : dict
+                A dictionary containing the run stopping condition (post_request, logcat_regex, function),
+                the regex (in case of logcat_regex) and optional options (port number in case of post_request).
+            queue : multiprocessing.Queue
+                The queue that is shared among the main process and child processes.
+            interaction_function : function
+                The interaction function that represents the run.
+            device : AndroidRunner.Device
+                The device for the current run.
+            path : str
+                The path for the current run
+            run : int
+                The currents run count.
+            *args
+                Variable length argument list
+            **kwargs
+                Arbitrary keyword arguments.
+        """
+        self.run_stopping_condition_config = run_stopping_condition_config
+        self.queue = queue
+        self.interaction_function = interaction_function
+        self.device = device
+        self.path = path
+        self.args = args
+        self.kwargs = kwargs
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        self.condition = next(iter(self.run_stopping_condition_config))
+        if self.condition not in ["function", "post_request", "logcat_regex"]:
+            raise ConfigError("Given run_stopping_condition is not accepted. Accepted values are function, post_request or logcat_regex")
+        
+        self.regex = run_stopping_condition_config[self.condition].get("regex", None)
+        if self.condition == "logcat_regex" and self.regex == None:
+            raise ConfigError("A regex must be given when run_stopping_condition is set to logcat_regex.")
+
+        self.server_port = run_stopping_condition_config[self.condition].get("port", StopRunWebserver.DEFAULT_SERVER_PORT)
+        if not isinstance(self.server_port, int):
+            raise ConfigError("Provided server port for run_stopping_condition value must be an integer.")
+
+    @keyboardinterrupt_handler
+    def _mp_interaction(self, queue, interaction_function, device, path, run, *args, **kwargs):
+        """ Runs the provided interaction_function and when done writes to the central shared <queue>.
+
+        Parameters
+        ----------
+        queue : multiprocessing.Queue
+            The queue that is shared among the main process and child processes.
+        interaction_function : function
+            The interaction function (run) that needs to be executed and which can be prematurely stopped.
+        device : AndroidRunner.Device
+            The device for the current run.
+        path : str 
+            The path for the current run
+        run : int
+            The current run count.
+        *args
+            Variable length argument list
+        **kwargs
+            Arbitrary keyword arguments.
+        """
+        interaction_function(device, path, run, *args, **kwargs)
+        queue.put("interaction")
+
+    @keyboardinterrupt_handler
+    def _mp_logcat_regex(self, queue, device, regex):
+        """ Keeps checking the logcat of the <device> until an 
+            entry matching the <regex> is found. When done it writes
+            to the shared <queue> so main process knows it can stop other process(es).
+
+            Parameters
+            ----------
+            queue : multiprocessing.Queue
+                The queue that is shared among the main process and child processes.
+            device : AndroidRunner.Device
+                The device for the current run.
+            regex : str
+                The regex that should be matched.
+        """
+        while not device.logcat_regex(regex):
+            time.sleep(1)
+        queue.put(PrematureStoppableRun.STOPPING_MECHANISM_LOGCAT_REGEX)
+
+    @keyboardinterrupt_handler
+    def _mp_post_request(self, queue, server_port):
+        """ Starts a local webserver on <server_port> that stops when a HTTP POST
+            request is received. It then writes to the central shared <queue>.
+
+            Parameters
+            ---------
+            queue : multiprocessing.Queue
+                The queue that is shared among the main process and child processes.
+            server_port : int
+                The port on which the local webserver is started.
+        """
+        self.logger.info(f"Starting webserver on port {server_port}.")
+        webServer = HTTPServer(("", server_port), StopRunWebserver)
+
+        # We "serve_forever" but the server will stop itself when a HTTP POST request was received.
+        webServer.serve_forever()
+        queue.put(PrematureStoppableRun.STOPPING_MECHANISM_HTTP_POST_REQUEST)
+
+    def run(self):
+        """ Runs the interaction (run) process in a new process which can be prematurely stopped by
+            the stop() function call, a receiving HTTP POST request or found regex. 
+        """
+        procs = []
+
+        # Start either a local webserver or continuously check the devices logcat for a regex in a new process.
+        # When the condition is set to "function" we don't need to start another process, only the interaction process.
+        if self.condition == "post_request":
+            procs.append(mp.Process(target=self._mp_post_request, args=(self.queue, self.server_port,)))
+        elif self.condition == "logcat_regex":
+            procs.append(mp.Process(target=self._mp_logcat_regex, args=(self.queue, self.device, self.regex,)))
+
+        # Always run the interaction (run).
+        procs.append(mp.Process(target=self._mp_interaction, args=(self.queue, self.interaction_function, self.device, self.path, self.run, *self.args,), kwargs=self.kwargs))
+
+        for proc in procs:
+            proc.start()
+
+        # Wait till one of the created processes writes to the queue. It means that that process is finished.
+        res = self.queue.get()
+
+        if res != "interaction":
+            self.logger.info(f"Run was prematurely stopped by means of a(n) {res}.")
+
+        # Terminate all processes also the ones that are not finished (since it may have child processes we have to kill them too).
+        for proc in procs:
+            parent = psutil.Process(proc.pid)
+
+            # Kill its child proccesses.
+            for child in parent.children(recursive=True):
+                child.terminate()
+
+            proc.terminate()

--- a/AndroidRunner/StopRunWebserver.py
+++ b/AndroidRunner/StopRunWebserver.py
@@ -1,0 +1,57 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading
+import paths
+import os.path as op
+import datetime
+from .util import makedirs
+import logging
+
+class StopRunWebserver(BaseHTTPRequestHandler):
+    DEFAULT_SERVER_PORT = 8000
+
+    def do_GET(self): #pragma: no cover
+        """ Handles incoming HTTP GET requests by:
+            - Showing a simple webpage telling that the server is running and ready for accepting requests.
+        """
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(bytes("<html><head><title>Android Runner HTTP Server</title></head>", "utf-8"))
+        self.wfile.write(bytes("<body>", "utf-8"))
+        self.wfile.write(bytes("<p>The Android Runner web server is running successfully!<br />", "utf-8"))
+        self.wfile.write(bytes("Send a POST request to this URL to stop the current run. </p>", "utf-8"))
+        self.wfile.write(bytes("</body></html>", "utf-8"))
+
+    def do_POST(self): #pragma: no cover
+        """ Handles incoming HTTP POST requests by:
+            1. writing the HTTP POST request payload to a file.
+            2. Stopping the server so the process can write to the queue and the run is stopped.
+        """ 
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        if self.headers["Content-Length"] != None and int(self.headers["Content-Length"]) > 0:
+            content_length = int(self.headers['Content-Length'])
+            post_data = self.rfile.read(content_length)
+
+            dir_path = op.join(paths.OUTPUT_DIR, "http_post_request_payloads") 
+            makedirs(dir_path)
+
+            file_ = datetime.datetime.now().strftime("%Y_%m_%dT%H_%M_%S_%f")
+            if self.headers["Content-type"] == "application/json":
+                filename = op.join(dir_path, f"{file_}.json")
+            else:
+                filename = op.join(dir_path, f"{file_}.txt")
+
+            with open(filename, 'w+') as opened_file:
+                opened_file.write(post_data.decode("utf-8"))
+                self.logger.info(f"Wrote HTTP POST request payload to {filename}")
+        else:
+            self.logger.info("Received HTP POST request did not contain a payload.")
+
+        self.send_response(200)
+        self.end_headers()
+
+        def kill_server(server):
+            server.shutdown()
+
+        threading.Thread(target=kill_server, args=(self.server,)).start()

--- a/AndroidRunner/WebExperiment.py
+++ b/AndroidRunner/WebExperiment.py
@@ -1,11 +1,12 @@
 import os.path as op
 import time
-
+import multiprocessing as mp
 from . import Tests
 import paths
 from .BrowserFactory import BrowserFactory
 from .Experiment import Experiment
 from .util import makedirs, slugify_dir
+from AndroidRunner.PrematureStoppableRun import PrematureStoppableRun 
 
 
 class WebExperiment(Experiment):
@@ -23,7 +24,13 @@ class WebExperiment(Experiment):
         self.before_run(device, path, run, browser)
         self.after_launch(device, path, run, browser)
         self.start_profiling(device, path, run, browser)
-        self.interaction(device, path, run, browser)
+
+        if self.run_stopping_condition_config:
+            premature_stoppable_run = PrematureStoppableRun(self.run_stopping_condition_config, self.queue, self.interaction, device, path, run, browser)
+            premature_stoppable_run.run()
+        else:
+            self.interaction(device, path, run, browser)
+
         self.stop_profiling(device, path, run, browser)
         self.before_close(device, path, run, browser)
         self.after_run(device, path, run, browser)
@@ -55,7 +62,6 @@ class WebExperiment(Experiment):
         browser.load_url(device, path)
         time.sleep(5)
         super(WebExperiment, self).interaction(device, path, run, *args, **kwargs)
-
         # TODO: Fix web experiments running longer than self.duration
         time.sleep(self.duration)
 

--- a/AndroidRunner/util.py
+++ b/AndroidRunner/util.py
@@ -1,4 +1,5 @@
 import errno
+import psutil
 import json
 import time
 import os
@@ -97,3 +98,20 @@ def slugify_dir(value):
     regex_pattern = r'[^\w]'
     slug = slugify(value, regex_pattern=regex_pattern)
     return slug
+
+def keyboardinterrupt_handler(func):
+    """ Decorator that ensures that a KeyBoardInterrupt is handled
+        cleanly by terminating the associated process.
+
+        Is necessary as a KeyBoardInterrupt is send to a process and all of its child processes.
+        Each process therefore needs its own handler.
+
+        Can be used by putting @keyboardinterrupt_handler above a function.
+    """
+    def inner_function(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except KeyboardInterrupt as e:
+            this_process = psutil.Process()
+            this_process.terminate()
+    return inner_function

--- a/README.md
+++ b/README.md
@@ -92,6 +92,37 @@ Restarts the adb connection after each run.  Default is *false*.
 **time_between_run** *positive integer*
 The time that the framework waits between 2 successive experiment runs. Default is 0.
 
+The **run_stopping_condition** makes it possible to stop the current run when a specific event is triggered. If no event is triggered the run will continue as usual. Right now there are 3 supported events. When the logcat_regex or post_request conditions are used users can also stop the run by using the stop() function call.
+
+1. A regex in the logcat is matched.
+
+      With the configuration below AR continuously checks if the device's logcat contains an entry matching the "\<expr\>" where "\<expr\>" is a regular expression. If this is the case the run will be stopped. Please note that the `regex` option is required to specify the regex.
+      ```js
+      "run_stopping_condition" : {"logcat_regex" : {"regex" : "<expr>"}}
+      ```
+2. The reception of an HTTP POST request.
+
+    With the configuration below AR will start a local webserver on port 2222 which accepts HTTP POST requests to stop the run. The payload of these HTTP POST requests are saved to the output directory. The file format will be .json if the Content-type header is `application/json` and .txt otherwise.
+    ```js
+    "run_stopping_condition" : {"post_request" : {"server_port" : 2222}}
+    ```
+    The `server_port` option is optional. If it is not provided the local webserver will be started on port 8000.
+
+3. A direct call of the stop() function on an Experiment instance.   
+
+    With the configuration below AR allows one to call the stop() method on an AndroidRunner.Experiment instance to stop the current run.  
+    ```js
+    "run_stopping_condition" : {"function" : {}}
+    ```
+    This can be useful in an interaction script when we want to stop the run if some condition holds. The current Experiment instance can be accessed by `args[0]`. An example which stops the run if "certain app" is installed on the device.
+    ```py
+    def main(device, *args, **kwargs):
+      if device.is_installed("certain app"):
+        args[0].stop()
+    ```
+
+
+
 **devices** *JSON*
 A JSON object to describe the devices to be used and their arguments. Below are several examples:
 ```js

--- a/devices.json
+++ b/devices.json
@@ -4,5 +4,6 @@
   "xcompact": "BH904E9V5P",
   "j7duo": "520044f84b4835f5",
   "j7duo2": "52004f53fe46357d",
-  "lgg6": "LGH872d131f09c"
+  "lgg6": "LGH872d131f09c",
+  "pixel5g": "0A101FDD40030R"
 }

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -219,7 +219,7 @@ class TestScript(object):
         temp_file = tmpdir.join("script.py")
         temp_file.write('\n'.join(['from time import sleep',
                                    'def main(device_id):\n',
-                                   '    sleep(0.5)\n'
+                                   '    sleep(2.5)\n'
                                    '    return "succes"']))
         return str(temp_file)
 
@@ -259,7 +259,7 @@ class TestScript(object):
 
     def test_script_run_timeout(self, script_path):
         fake_device = Mock()
-        assert Python3(script_path, timeout=10).run(fake_device) == 'timeout'
+        assert Python3(script_path, timeout=1).run(fake_device) == 'timeout'
 
     def test_script_run_logcat(self, script_path):
         fake_device = Mock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,9 +1,9 @@
 import os
 import os.path as op
-
+from http import server
+from io import BytesIO as IO
 import pytest
 from mock import Mock, patch
-
 import AndroidRunner.Tests as Tests
 import AndroidRunner.util as util
 import paths
@@ -63,6 +63,16 @@ class TestUtilClass(object):
 
         with pytest.raises(TimeoutError):
             util.wait_until(func_, 5)
+
+    @patch("psutil.Process")
+    def test_keyboardinterrupt_handler(self, psutil_mock):
+        def test_function():
+            raise KeyboardInterrupt
+
+        new_function = util.keyboardinterrupt_handler(test_function)
+        new_function()
+
+        psutil_mock.terminate.called_once()
 
     def test_makedirs_succes(self, tmpdir):
         dir_path = op.join(str(tmpdir), 'test1')
@@ -147,7 +157,8 @@ class TestPathsClass(object):
         assert paths_dict['BASE_OUTPUT_DIR'] == string_base
         assert paths_dict['ORIGINAL_CONFIG_DIR'] == string_original
 
-
+        
+        
 
 class TestTestsClass(object):
     def test_is_integer_not_int(self):


### PR DESCRIPTION
Provided AR with run_stopping_condition option in config which supports 3 events:

- logcat_regex: stops the run when a regex is matched in the device's logcat.
- post_request: stops the run when a HTTP POST request is received at the local webserver
- function: stops the run when the stop() function is called on the Experiment instance.

This commit includes:
- Code
- README.md additions
- Tests