### PR TITLE
programmatically disable USB charging before run and enable it afterwards

### DIFF
--- a/AndroidRunner/USBHandler.py
+++ b/AndroidRunner/USBHandler.py
@@ -1,0 +1,81 @@
+import subprocess
+from .util import ConfigError
+
+class USBHandler(object):
+    USB_COMMAND_TIMEOUT_SECONDS = 5
+
+    def __init__(self, usb_handler_config):
+        """ Inits an USBHandler instance.
+
+            Parameters
+            ----------
+            usb_handler_config : dict
+                Dictionary containing the keys enable_command, disable_command
+                with the enable and disable commands as values, respectively.
+        """
+        self._usb_enabled = True
+
+        if usb_handler_config == None:
+            self.usb_enable_command = None
+            self.usb_disable_command = None 
+            self._usb_enabled = None
+            return
+
+        if usb_handler_config.get("enable_command", None) == None:
+            raise ConfigError("Please provide an enable_command for the usb_handler.")
+
+        if usb_handler_config.get("disable_command", None) == None:
+            raise ConfigError("Please provide an disable_command for the usb_handler.")
+
+        self.usb_enable_command = usb_handler_config["enable_command"]
+        self.usb_disable_command = usb_handler_config["disable_command"]
+
+
+    def enable_usb(self):
+        """ Enables the USB port(s) is non-empty usb_handler_config is given when instantiating the class.
+
+            Please note that Android Runner also calls the device.unplug() at the beginning
+            of the experiment and only calls device.plug() at the end of the experiment.
+            This only mocks the battery status (so it looks like its unplugged) but it does 
+            NOT actually stop charging the device through USB.
+            Please take this into account when it seems like enabling the 
+            USB port(s) does not seem to work ;).
+        
+        """
+        # Check first whether USB port(s) are "really" disabled otherwise the call in Experiment.cleanup()
+        # can result in disabled ports when using same enable and disable command.
+        if self._usb_enabled == False:
+            self._run_command(self.usb_enable_command)
+            self._usb_enabled = True
+
+    def disable_usb(self):
+        """ Disables the USB port(s) if non-empty usb_handler_config is given when instantiating the class."""
+        if self._usb_enabled == True:
+            self._run_command(self.usb_disable_command)
+            self._usb_enabled = False
+
+    def _run_command(self, command):
+        """ Runs given command
+
+        Parameters
+        ----------
+        command : string
+            Command that needs to be run.
+        """
+        if command == None:
+            return
+
+        command = command.split()
+        proc = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        try:
+            (stdout, stderr) = proc.communicate(timeout=USBHandler.USB_COMMAND_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            raise USBHandlerException("TimeOutError while executing USB command.")
+
+        if stderr:
+            err = stderr.decode("ascii")
+            raise USBHandlerException(f"Could not execute USB command: {err}")
+
+class USBHandlerException(Exception):
+    pass

--- a/AndroidRunner/WebExperiment.py
+++ b/AndroidRunner/WebExperiment.py
@@ -22,9 +22,15 @@ class WebExperiment(Experiment):
                 browser = browserItem
         self.before_run(device, path, run, browser)
         self.after_launch(device, path, run, browser)
+
+        self.usb_handler.disable_usb()
         self.start_profiling(device, path, run, browser)
+
         self.interaction(device, path, run, browser)
+
         self.stop_profiling(device, path, run, browser)
+        self.usb_handler.enable_usb()
+
         self.before_close(device, path, run, browser)
         self.after_run(device, path, run, browser)
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ Restarts the adb connection after each run.  Default is *false*.
 **time_between_run** *positive integer*
 The time that the framework waits between 2 successive experiment runs. Default is 0.
 
+The **usb_handler** option enables Android Runner to disable the USB connection during each run (while AR is profiling) and enables it after the run. This allows
+devices to charge inbetween runs. In addition, some (energy) profilers can only provide accurate measurements when there is no charge flowing into the battery during profiling. To use this option the device(s) should be connected to ADB using WiFi.
+The option expects a JSON object with "enable_command" and "disable_command" as keys and the corresponding commands as values.
+
+```js
+"usb_handler" : {
+                "enable_command"  : "uhubctl -l 2 -a 1",
+                "disable_command" : "uhubctl -l 2 -a 0" 
+                }
+```
+The example above uses [uhubtl](https://github.com/mvp/uhubctl), an utilitiy that makes it possible to programmatically enable and disable USB port(s). Please note
+uhubctl is only compatible with a selection of devices (see the full list on GitHub). We have used and tested uhubctl primarily on a Raspberry PI 4B. There are a few caveats when using uhubctl on the Raspberry PI 4B:
+- You cannot specify which USB port to enable or disable. Either ALL USB ports are enabled or ALL USB ports are disabled.
+- When a USB block/mass storage device is connected, in addition to your device(s) under test, it is likely that the power will turn back on after a few seconds. This is caused by the fact that some device drivers in the kernel are surprised by USB device being turned off and automatically try to power it back on.
+The easiest way to fix this issue to disconnect the USB block/mass storage. An alternative is to use the `udiskctl`, see [here](https://github.com/mvp/uhubctl#usb-devices-are-not-removed-after-port-power-down-on-linux) for more info.
+
 **devices** *JSON*
 A JSON object to describe the devices to be used and their arguments. Below are several examples:
 ```js


### PR DESCRIPTION
This adds the usb_handler option in the configuration. This makes it possible to programmatically disable the USB charging/power before a run and enable it afterwards.

This commit includes:
- Code
- Tests
- README.md updates