### PR TITLE
Fix for Trepn not working when connected to ADB through WiFi

### DIFF
--- a/AndroidRunner/Plugins/trepn/Trepn.py
+++ b/AndroidRunner/Plugins/trepn/Trepn.py
@@ -121,7 +121,7 @@ class Trepn(Profiler):
         # Gives the latest result
         db = device.shell(r'ls %s | grep "\.db$"' % Trepn.DEVICE_PATH).strip().splitlines()
         newest_db = db[len(db) - 1]
-        csv_filename = '%s_%s.csv' % (device.id, op.splitext(newest_db)[0])
+        csv_filename = '%s_%s.csv' % (util.slugify(device.id), op.splitext(newest_db)[0])
         if newest_db:
             device.shell('am broadcast -a com.quicinc.trepn.export_to_csv '
                          '-e com.quicinc.trepn.export_db_input_file "%s" '


### PR DESCRIPTION
When Trepn is used and the device is connected to ADB through WiFi it would be impossible for Trepn to convert the profiling database to a .csv file resulting in a TimeoutError (since it cannot find the csv file within a given time period).

The cause was that the .csv filename was generated based upon the device.id which contains characters that are not valid in filenames. AndroidRunner.util.slugify was used to convert device.id to valid filename.