### PR TITLE
Added access-control-allow-origin header to prevent CORS warnings in browser.

### DIFF
--- a/AndroidRunner/StopRunWebserver.py
+++ b/AndroidRunner/StopRunWebserver.py
@@ -49,6 +49,7 @@ class StopRunWebserver(BaseHTTPRequestHandler):
             self.logger.info("Received HTP POST request did not contain a payload.")
 
         self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
 
         def kill_server(server):


### PR DESCRIPTION
Adds the access-control-allow-origin header to the local webserver to prevent CORS warnings in some browsers when sending a HTTP POST request.