### PR TITLE
`adb install -t` to allow test packages

### DIFF
--- a/AndroidRunner/Adb.py
+++ b/AndroidRunner/Adb.py
@@ -113,6 +113,7 @@ def install(device_id, apk, replace=True, all_permissions=True):
         cmd += ' -r'
     if all_permissions:
         cmd += ' -g'
+    cmd += ' -t'
     adb.run_cmd('%s %s' % (cmd, apk))
     # WARNING: Accessing class private variables
     output = adb._ADB__output

--- a/tests/unit/test_devices.py
+++ b/tests/unit/test_devices.py
@@ -752,7 +752,7 @@ class TestAdb(object):
         result = Adb.install(device_id, apk)
 
         assert result == 'succes'
-        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g {}'.format(apk))]
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -g -t {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
     @patch("zipfile.ZipFile")
@@ -770,7 +770,7 @@ class TestAdb(object):
         result = Adb.install(device_id, xapk_file)
 
         assert result == 'succes'
-        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install-multiple -r -g {}'.format(apk_file))]
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install-multiple -r -g -t {}'.format(apk_file))]
         assert mock_adb.mock_calls == expected_calls
 
     @patch("zipfile.ZipFile")
@@ -796,7 +796,7 @@ class TestAdb(object):
         result = Adb.install(device_id, apk, replace=False)
 
         assert result == 'succes'
-        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -g {}'.format(apk))]
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -g -t {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
     def test_install_not_all_permissions(self):
@@ -809,7 +809,7 @@ class TestAdb(object):
         result = Adb.install(device_id, apk, all_permissions=False)
 
         assert result == 'succes'
-        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r {}'.format(apk))]
+        expected_calls = [call.set_target_by_name(device_id), call.run_cmd('install -r -t {}'.format(apk))]
         assert mock_adb.mock_calls == expected_calls
 
     @patch('AndroidRunner.Adb.success_or_exception')


### PR DESCRIPTION
When android runner tried to install APKs, the following error was raised:

```log
Traceback (most recent call last):
  File "/home/pi/android-runner/AndroidRunner/Experiment.py", line 80, in start
    self.run_experiment(current_run)                                                                     
  File "/home/pi/android-runner/AndroidRunner/Experiment.py", line 106, in run_experiment
    self.run_run(current_run)
  File "/home/pi/android-runner/AndroidRunner/Experiment.py", line 119, in run_run
    self.run(self.devices.get_device(current_run['device']), current_run['path'],
  File "/home/pi/android-runner/AndroidRunner/Experiment.py", line 192, in run
    self.before_run(device, path, run)        
  File "/home/pi/android-runner/AndroidRunner/NativeExperiment.py", line 42, in before_run
    device.launch_package(self.package)
  File "/home/pi/android-runner/AndroidRunner/Device.py", line 182, in launch_package
    raise AdbError('Could not launch "{}"'.format(package))               
AndroidRunner.Adb.AdbError: Could not launch "com.example.helloworld"
```

Adb version:

```log
pi@raspberrypi:~/android-runner $ adb --help

Android Debug Bridge version 1.0.41                                                                      
Version 28.0.2-debian                                                                                    
Installed as /usr/lib/android-sdk/platform-tools/adb
```